### PR TITLE
Extension to enable a feature in unit test by annotation

### DIFF
--- a/junit/src/main/java/org/togglz/junit/TogglzRule.java
+++ b/junit/src/main/java/org/togglz/junit/TogglzRule.java
@@ -85,6 +85,11 @@ public class TogglzRule implements TestRule {
                     TestFeatureManagerProvider.setFeatureManager(featureManager);
                     FeatureContext.clearCache();
 
+                    WithFeature withFeature = description.getAnnotation(WithFeature.class);                    
+                    if ( withFeature != null) {
+                        enableFeature(withFeature);
+                    }
+                    
                     // run the test
                     base.evaluate();
 
@@ -95,6 +100,18 @@ public class TogglzRule implements TestRule {
                     TestFeatureManagerProvider.setFeatureManager(null);
                 }
 
+            }
+            
+            void enableFeature(WithFeature withFeature)
+            {
+                Feature[] features = withFeature.type().getEnumConstants();
+                if (features != null) {
+                    for (Feature feature : features) {
+                        if ( feature.name().equals(withFeature.value()) ) {
+                            enable(feature);
+                        }
+                    }
+                }
             }
         };
 

--- a/junit/src/main/java/org/togglz/junit/WithFeature.java
+++ b/junit/src/main/java/org/togglz/junit/WithFeature.java
@@ -1,0 +1,20 @@
+package org.togglz.junit;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.togglz.core.Feature;
+
+/**
+ * Used together with the {@link TogglzRule} on test methods.
+ */
+@Target({METHOD}) 
+@Retention(RUNTIME)
+public @interface WithFeature
+{
+    Class<? extends Feature> type();
+    String value();
+}

--- a/junit/src/test/java/org/togglz/junit/TogglzRuleWithAnnotationTest.java
+++ b/junit/src/test/java/org/togglz/junit/TogglzRuleWithAnnotationTest.java
@@ -1,0 +1,26 @@
+package org.togglz.junit;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TogglzRuleWithAnnotationTest {
+
+    @Rule
+    public TogglzRule togglzRule = TogglzRule.allDisabled(MyFeatures.class);
+
+    @Before
+    public void setUp()
+    {
+        Assert.assertTrue(MyFeatures.FEATURE_ONE.isActive());
+    }
+    
+    @Test
+    @WithFeature(type=MyFeatures.class, value="FEATURE_ONE")
+    public void test_enabledByAnnotation()
+    {
+        Assert.assertTrue(MyFeatures.FEATURE_ONE.isActive());
+    }
+
+}


### PR DESCRIPTION
Hi Christian,

I implemented an extension to the TogglzRule which allows to annotate test methods with
a new annotation @WithFeature.

This has the advantage that the feature is already enabled when the setup methods are called and it makes it more obvious that a test method tests a specific feature.

Please have a look at it and see if you can use it.

Best regards
Achim
