### PR TITLE
#56 - hashCode and equals for NamedFeature

### DIFF
--- a/core/src/main/java/org/togglz/core/util/NamedFeature.java
+++ b/core/src/main/java/org/togglz/core/util/NamedFeature.java
@@ -21,4 +21,13 @@ public class NamedFeature implements Feature {
         return name;
     }
 
+	@Override
+	public int hashCode() {
+		return name.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return (o instanceof NamedFeature) ? this.name.equals(((NamedFeature)o).name()) : false;
+	}
 }


### PR DESCRIPTION
NamedFeature is used as a key in the CachingStateRepository and without
these methods it's impossible to retrieve cached features.
