### PR TITLE
to make the static FeatureManager visible to all threads in the JVM, it ...

### DIFF
--- a/core/src/main/java/org/togglz/core/context/StaticFeatureManagerProvider.java
+++ b/core/src/main/java/org/togglz/core/context/StaticFeatureManagerProvider.java
@@ -12,7 +12,7 @@ import org.togglz.core.spi.FeatureManagerProvider;
  */
 public class StaticFeatureManagerProvider implements FeatureManagerProvider {
 
-    private static FeatureManager staticInstance = null;
+    private static volatile FeatureManager staticInstance = null;
 
     @Override
     public int priority() {


### PR DESCRIPTION
...needs to be declared volatile
