### PR TITLE
Add new "var" property to taglib

### DIFF
--- a/jsp/src/main/java/org/togglz/jsp/ActiveFeatureTag.java
+++ b/jsp/src/main/java/org/togglz/jsp/ActiveFeatureTag.java
@@ -1,6 +1,7 @@
 package org.togglz.jsp;
 
 import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.Tag;
 import javax.servlet.jsp.tagext.TagSupport;
 
@@ -16,6 +17,8 @@ public class ActiveFeatureTag extends TagSupport {
     protected FeatureManager featureManager;
 
     protected String name;
+    
+    protected String var;
 
     public ActiveFeatureTag() {
         this.featureManager = new LazyResolvingFeatureManager();
@@ -23,10 +26,13 @@ public class ActiveFeatureTag extends TagSupport {
 
     @Override
     public int doStartTag() throws JspException {
-        if (isFeatureActive()) {
-            return Tag.EVAL_BODY_INCLUDE;
-        }
-        return Tag.SKIP_BODY;
+    	boolean isActive = isFeatureActive();
+        
+        if (Strings.isNotBlank(var)) {
+             pageContext.setAttribute(var, isActive, PageContext.PAGE_SCOPE);
+         }
+        
+        return isActive ? Tag.EVAL_BODY_INCLUDE : Tag.SKIP_BODY;
     }
 
     protected boolean isFeatureActive() {
@@ -43,7 +49,15 @@ public class ActiveFeatureTag extends TagSupport {
     public void setName(String name) {
         this.name = name;
     }
-
+    
+    public String getVar() {
+    	return var;
+    }
+    
+    public void setVar(String var) {
+        this.var = var;
+    }
+    
     public FeatureManager getFeatureManager() {
         return featureManager;
     }

--- a/jsp/src/main/resources/META-INF/togglz.tld
+++ b/jsp/src/main/resources/META-INF/togglz.tld
@@ -13,6 +13,11 @@
       <name>name</name>
       <required>true</required>
     </attribute>
+    <attribute>
+	<name>var</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+	</attribute>
   </tag>
 </taglib>
 


### PR DESCRIPTION
The new var property gives the taglib the capability to store the state
of a feature in a page context variable. This is useful when you want
to use the result in EL expressions (amongst other uses).

No unit tests were written. I tried. I tried hard. But configuring the arquillian container on my setup proved to be above my IQ levels. 
