### PR TITLE
#71 Added ActivationStrategyProvider with default implementation

### DIFF
--- a/core/src/main/java/org/togglz/core/activation/ActivationStrategyProvider.java
+++ b/core/src/main/java/org/togglz/core/activation/ActivationStrategyProvider.java
@@ -1,0 +1,19 @@
+package org.togglz.core.activation;
+
+import java.util.List;
+import java.util.ServiceLoader;
+
+import org.togglz.core.spi.ActivationStrategy;
+
+/**
+ * Implementations of this interface are responsible for providing the activation strategies. The default implementation
+ * {@link DefaultActivationStrategyProvider} uses the standard JDK {@link ServiceLoader} mechanism to discover strategies.
+ * 
+ * @author Jesse Kershaw
+ * 
+ */
+public interface ActivationStrategyProvider {
+
+	List<ActivationStrategy> getActivationStrategys();
+	
+}

--- a/core/src/main/java/org/togglz/core/activation/DefaultActivationStrategyProvider.java
+++ b/core/src/main/java/org/togglz/core/activation/DefaultActivationStrategyProvider.java
@@ -1,0 +1,24 @@
+package org.togglz.core.activation;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import org.togglz.core.spi.ActivationStrategy;
+import org.togglz.core.util.Lists;
+
+public class DefaultActivationStrategyProvider implements
+		ActivationStrategyProvider {
+
+	private final List<ActivationStrategy> strategies;
+	
+	public DefaultActivationStrategyProvider() {
+        this.strategies = Lists.asList(ServiceLoader.load(ActivationStrategy.class).iterator());
+	}
+	
+	@Override
+	public List<ActivationStrategy> getActivationStrategys() {
+		return Collections.unmodifiableList(this.strategies);
+	}
+
+}

--- a/core/src/main/java/org/togglz/core/activation/GradualActivationStrategy.java
+++ b/core/src/main/java/org/togglz/core/activation/GradualActivationStrategy.java
@@ -21,11 +21,12 @@ public class GradualActivationStrategy implements ActivationStrategy {
 
     private final Log log = LogFactory.getLog(GradualActivationStrategy.class);
     
+	public static final String ID = "gradual";
     public static final String PARAM_PERCENTAGE = "percentage";
 
     @Override
     public String getId() {
-        return "gradual";
+        return ID;
     }
 
     @Override

--- a/core/src/main/java/org/togglz/core/manager/DefaultFeatureManager.java
+++ b/core/src/main/java/org/togglz/core/manager/DefaultFeatureManager.java
@@ -1,11 +1,10 @@
 package org.togglz.core.manager;
 
 import java.util.Collections;
-import java.util.List;
-import java.util.ServiceLoader;
 import java.util.Set;
 
 import org.togglz.core.Feature;
+import org.togglz.core.activation.ActivationStrategyProvider;
 import org.togglz.core.metadata.EmptyFeatureMetaData;
 import org.togglz.core.metadata.FeatureMetaData;
 import org.togglz.core.repository.FeatureState;
@@ -14,7 +13,6 @@ import org.togglz.core.spi.ActivationStrategy;
 import org.togglz.core.spi.FeatureProvider;
 import org.togglz.core.user.FeatureUser;
 import org.togglz.core.user.UserProvider;
-import org.togglz.core.util.Lists;
 import org.togglz.core.util.Validate;
 
 /**
@@ -28,17 +26,16 @@ public class DefaultFeatureManager implements FeatureManager {
     private final String name;
     private final StateRepository stateRepository;
     private final UserProvider userProvider;
-    private final List<ActivationStrategy> strategies;
     private final FeatureProvider featureProvider;
+	private final ActivationStrategyProvider activationStrategyProvider;
 
     DefaultFeatureManager(String name, FeatureProvider featureProvider, StateRepository stateRepository,
-        UserProvider userProvider) {
+        UserProvider userProvider, ActivationStrategyProvider activationStrategyProvider) {
         this.name = name;
         this.featureProvider = featureProvider;
         this.stateRepository = stateRepository;
         this.userProvider = userProvider;
-        this.strategies = Lists.asList(ServiceLoader.load(ActivationStrategy.class).iterator());
-        Validate.notEmpty(strategies, "No ActivationStrategy implementations found");
+		this.activationStrategyProvider = activationStrategyProvider;
     }
 
     @Override
@@ -83,7 +80,7 @@ public class DefaultFeatureManager implements FeatureManager {
             FeatureUser user = userProvider.getCurrentUser();
 
             // check the selected strategy
-            for (ActivationStrategy strategy : strategies) {
+            for (ActivationStrategy strategy : activationStrategyProvider.getActivationStrategys()) {
                 if (strategy.getId().equalsIgnoreCase(strategyId)) {
                     return strategy.isActive(state, user);
                 }

--- a/core/src/main/java/org/togglz/core/manager/FeatureManagerBuilder.java
+++ b/core/src/main/java/org/togglz/core/manager/FeatureManagerBuilder.java
@@ -2,6 +2,8 @@ package org.togglz.core.manager;
 
 import java.util.UUID;
 import org.togglz.core.Feature;
+import org.togglz.core.activation.ActivationStrategyProvider;
+import org.togglz.core.activation.DefaultActivationStrategyProvider;
 import org.togglz.core.repository.StateRepository;
 import org.togglz.core.repository.mem.InMemoryStateRepository;
 import org.togglz.core.spi.FeatureProvider;
@@ -20,6 +22,7 @@ public class FeatureManagerBuilder {
     private FeatureProvider featureProvider = null;
     private StateRepository stateRepository = new InMemoryStateRepository();
     private UserProvider userProvider = new NoOpUserProvider();
+    private ActivationStrategyProvider activationStrategyProvider = new DefaultActivationStrategyProvider();
 
     /**
      * Use the supplied state repository for the feature manager.
@@ -82,6 +85,14 @@ public class FeatureManagerBuilder {
     }
 
     /**
+     * Use the supplied {@link ActivationStrategyProvider} for the activation strategies;
+     */
+    public FeatureManagerBuilder activationStrategyProvider(ActivationStrategyProvider activationStrategyProvider) {
+    	this.activationStrategyProvider = activationStrategyProvider;
+    	return this;
+    }
+        
+    /**
      * Initialize the builder with the configuration from the supplied {@link TogglzConfig} instance.
      */
     public FeatureManagerBuilder togglzConfig(TogglzConfig config) {
@@ -99,7 +110,8 @@ public class FeatureManagerBuilder {
         Validate.notNull(featureProvider, "No feature provider specified");
         Validate.notNull(stateRepository, "No state repository specified");
         Validate.notNull(userProvider, "No user provider specified");
-        return new DefaultFeatureManager(name, featureProvider, stateRepository, userProvider);
+        Validate.notNull(activationStrategyProvider, "No activation strategy provider specified");
+        return new DefaultFeatureManager(name, featureProvider, stateRepository, userProvider, activationStrategyProvider);
     }
 
 }

--- a/core/src/main/java/org/togglz/core/spi/ActivationStrategy.java
+++ b/core/src/main/java/org/togglz/core/spi/ActivationStrategy.java
@@ -1,7 +1,5 @@
 package org.togglz.core.spi;
 
-import java.util.ServiceLoader;
-
 import org.togglz.core.activation.Parameter;
 import org.togglz.core.activation.ParameterBuilder;
 import org.togglz.core.repository.FeatureState;
@@ -11,7 +9,7 @@ import org.togglz.core.user.UserProvider;
 
 /**
  * This interface represents a custom strategy for deciding whether a feature is active or not. Togglz ships with a few default
- * implementations. Implementations are discovered using the standard JDK {@link ServiceLoader} mechanism.
+ * implementations.
  * 
  * @author Christian Kaltepoth
  */

--- a/core/src/test/java/org/togglz/core/activation/DefaultActivationStrategyProviderTest.java
+++ b/core/src/test/java/org/togglz/core/activation/DefaultActivationStrategyProviderTest.java
@@ -1,0 +1,44 @@
+package org.togglz.core.activation;
+
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.togglz.core.spi.ActivationStrategy;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+public class DefaultActivationStrategyProviderTest {
+
+	private DefaultActivationStrategyProvider activateStrategyProvider;
+	
+	@Before
+	public void setup() {
+		this.activateStrategyProvider = new DefaultActivationStrategyProvider();
+	}
+	
+	@Test
+	public void testGetActivationStrategy() {
+		final List<ActivationStrategy> activationStrategys = this.activateStrategyProvider.getActivationStrategys();
+		// extract IDs from list of resolved strategies for assertion
+		final List<String> strategyIds = Lists.transform(activationStrategys, new Function<ActivationStrategy, String>() {
+			@Override
+			public String apply(ActivationStrategy strategy) {
+				return strategy.getId();
+			}
+		});
+		assertThat(strategyIds).contains(
+				UsernameActivationStrategy.ID, 
+				GradualActivationStrategy.ID,  
+				ScriptEngineActivationStrategy.ID, 
+				ReleaseDateActivationStrategy.ID, 
+				ServerIpActivationStrategy.ID, 
+				UserRoleActivationStrategy.ID);
+	}
+
+}

--- a/core/src/test/java/org/togglz/core/manager/DefaultFeatureManagerTest.java
+++ b/core/src/test/java/org/togglz/core/manager/DefaultFeatureManagerTest.java
@@ -28,6 +28,8 @@ public class DefaultFeatureManagerTest {
         repository.setFeatureState(new FeatureState(MyFeatures.DELETE_USERS, true)
             .setStrategyId(UsernameActivationStrategy.ID)
             .setParameter(UsernameActivationStrategy.PARAM_USERS, "admin"));
+        repository.setFeatureState(new FeatureState(MyFeatures.MISSING_STRATEGY, true)
+        	.setStrategyId("NoSuchActivationStrategy"));
         repository.setFeatureState(new FeatureState(MyFeatures.EXPERIMENTAL, false));
 
         featureUserProvider = new TestFeatureUserProvider();
@@ -50,8 +52,7 @@ public class DefaultFeatureManagerTest {
     @Test
     public void testGetFeatures() {
         assertThat(manager.getFeatures())
-            .hasSize(2)
-            .containsExactly(MyFeatures.DELETE_USERS, MyFeatures.EXPERIMENTAL);
+        	.contains(MyFeatures.DELETE_USERS, MyFeatures.EXPERIMENTAL, MyFeatures.MISSING_STRATEGY);
     }
 
     @Test
@@ -73,6 +74,8 @@ public class DefaultFeatureManagerTest {
         featureUserProvider.setFeatureUser(null);
         assertEquals(false, manager.isActive(MyFeatures.EXPERIMENTAL));
 
+        // MISSING_STRATEGY disabled for all
+    	assertEquals(false, manager.isActive(MyFeatures.MISSING_STRATEGY));
     }
 
     @Test
@@ -125,7 +128,8 @@ public class DefaultFeatureManagerTest {
      */
     private static enum MyFeatures implements Feature {
         DELETE_USERS,
-        EXPERIMENTAL;
+        EXPERIMENTAL,
+        MISSING_STRATEGY;
     }
 
 }


### PR DESCRIPTION
- Default implementation uses ServiceLoader to discover strategies
- Added activationStrategyProvider to FeatureManagerBuilder
- Resolved Activation Strategies may be empty in DefaultFeatureManager
- Added static ID to GradualActivationStrategy
- Added test case for when the activation strategy is not found for a
  FeatureState
