### PR TITLE
#73 support type level Feature Groups annotation:

### DIFF
--- a/core/src/main/java/org/togglz/core/util/FeatureAnnotations.java
+++ b/core/src/main/java/org/togglz/core/util/FeatureAnnotations.java
@@ -1,10 +1,11 @@
 package org.togglz.core.util;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.togglz.core.Feature;
 import org.togglz.core.annotation.EnabledByDefault;
 import org.togglz.core.annotation.FeatureAttribute;
@@ -13,12 +14,10 @@ import org.togglz.core.annotation.Label;
 import org.togglz.core.annotation.Owner;
 
 /**
- * 
  * Utility class to read annotation on feature enums.
- * 
+ *
  * @author Christian Kaltepoth
  * @author Eli Abramovitch
- * 
  */
 public class FeatureAnnotations {
 
@@ -54,22 +53,32 @@ public class FeatureAnnotations {
         return getAnnotation(feature, annotationType) != null;
     }
 
-    public static Annotation[] getAnnotations(Feature feature) {
+    public static Set<Annotation> getAnnotations(Feature feature) {
+        Set<Annotation> annotations = new HashSet<Annotation>();
         try {
-            Field field = feature.getClass().getField(feature.name());
-            return field.getAnnotations();
+            Class<? extends Feature> featureClass = feature.getClass();
+            Annotation[] fieldAnnotations = featureClass.getField(feature.name()).getAnnotations();
+            Annotation[] classAnnotations = featureClass.getAnnotations();
+
+            annotations.addAll(Arrays.asList(fieldAnnotations));
+            annotations.addAll(Arrays.asList(classAnnotations));
+
+            return annotations;
         } catch (SecurityException e) {
             // ignore
         } catch (NoSuchFieldException e) {
             // ignore
         }
-        return null;
+        return annotations;
     }
 
     public static <A extends Annotation> A getAnnotation(Feature feature, Class<A> annotationType) {
         try {
-            Field field = feature.getClass().getField(feature.name());
-            return field.getAnnotation(annotationType);
+            Class<? extends Feature> featureClass = feature.getClass();
+            A fieldAnnotation = featureClass.getField(feature.name()).getAnnotation(annotationType);
+            A classAnnotation = featureClass.getAnnotation(annotationType);
+
+            return fieldAnnotation != null ? fieldAnnotation : classAnnotation;
         } catch (SecurityException e) {
             // ignore
         } catch (NoSuchFieldException e) {
@@ -98,7 +107,7 @@ public class FeatureAnnotations {
                 Method method = annotation.getClass().getMethod(details.annotationAttribute());
                 if (method != null) {
                     String attributeValue = method.invoke(annotation).toString();
-                    return new String[] { attributeName, attributeValue };
+                    return new String[]{attributeName, attributeValue};
                 }
 
             }

--- a/core/src/test/java/org/togglz/core/metadata/enums/AnnotationFeatureGroupTest.java
+++ b/core/src/test/java/org/togglz/core/metadata/enums/AnnotationFeatureGroupTest.java
@@ -1,0 +1,67 @@
+package org.togglz.core.metadata.enums;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.Test;
+import org.togglz.core.Feature;
+import org.togglz.core.annotation.Label;
+import org.togglz.core.metadata.FeatureGroup;
+
+public class AnnotationFeatureGroupTest {
+
+    public static final String FIELD_LEVEL_GROUP_LABEL = "Field Level Group Label";
+    public static final String CLASS_LEVEL_GROUP_LABEL = "Class Level Group Label";
+
+    @org.togglz.core.annotation.FeatureGroup
+    @Label(FIELD_LEVEL_GROUP_LABEL)
+    @Target(ElementType.FIELD)
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface FieldLevelGroup {
+    }
+
+    @org.togglz.core.annotation.FeatureGroup
+    @Label(CLASS_LEVEL_GROUP_LABEL)
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface ClassLevelGroup {
+    }
+
+    @ClassLevelGroup
+    private enum TestFeatures implements Feature {
+
+        @FieldLevelGroup
+        FEATURE
+    }
+
+    @Test
+    public void buildWillReturnNullWhenFeatureGroupAnnotationIsNotPresent() throws Exception {
+        FeatureGroup result = AnnotationFeatureGroup.build(Label.class);
+
+        assertThat(result, nullValue());
+    }
+
+    @Test
+    public void buildWillReturnFeatureGroupWhenFeatureGroupAnnotationIsPresentForFieldLevelGroup() throws Exception {
+        FeatureGroup result = AnnotationFeatureGroup.build(FieldLevelGroup.class);
+
+        assertThat(result, notNullValue());
+        assertThat(result.getLabel(), is(FIELD_LEVEL_GROUP_LABEL));
+        assertThat(result.contains(TestFeatures.FEATURE), is(true));
+    }
+
+    @Test
+    public void buildWillReturnFeatureGroupWhenFeatureGroupAnnotationIsPresentForClassLevelGroup() throws Exception {
+        FeatureGroup result = AnnotationFeatureGroup.build(ClassLevelGroup.class);
+
+        assertThat(result, notNullValue());
+        assertThat(result.getLabel(), is(CLASS_LEVEL_GROUP_LABEL));
+        assertThat(result.contains(TestFeatures.FEATURE), is(true));
+    }
+}

--- a/core/src/test/java/org/togglz/core/metadata/enums/EnumFeatureMetaDataTest.java
+++ b/core/src/test/java/org/togglz/core/metadata/enums/EnumFeatureMetaDataTest.java
@@ -1,0 +1,73 @@
+package org.togglz.core.metadata.enums;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Set;
+import org.junit.Test;
+import org.togglz.core.Feature;
+import org.togglz.core.annotation.Label;
+import org.togglz.core.metadata.FeatureGroup;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+
+public class EnumFeatureMetaDataTest {
+
+    public static final String FIELD_LEVEL_GROUP_LABEL = "Field Level Group Label";
+    public static final String CLASS_LEVEL_GROUP_LABEL = "Class Level Group Label";
+
+    @org.togglz.core.annotation.FeatureGroup
+    @Label(FIELD_LEVEL_GROUP_LABEL)
+    @Target(ElementType.FIELD)
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface FieldLevelGroup {
+    }
+
+    @org.togglz.core.annotation.FeatureGroup
+    @Label(CLASS_LEVEL_GROUP_LABEL)
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface ClassLevelGroup {
+    }
+
+    @ClassLevelGroup
+    private enum TestFeatures implements Feature {
+
+        @FieldLevelGroup
+        FEATURE
+    }
+
+    @Test
+    public void constructorWillPopulateGroupsFromAnnotations() throws Exception {
+        // act
+        EnumFeatureMetaData metaData = new EnumFeatureMetaData(TestFeatures.FEATURE);
+
+        // assert
+        Set<FeatureGroup> groups = metaData.getGroups();
+
+        assertThat(groups, notNullValue());
+        assertThat(groups.size(), is(2));
+
+        // verify field level group is there
+        FeatureGroup group1 = Iterables.find(groups, createFeatureGroupLabelPredicate(FIELD_LEVEL_GROUP_LABEL));
+        assertThat(group1.contains(TestFeatures.FEATURE), is(true));
+
+        // verify class level group is there
+        FeatureGroup group2 = Iterables.find(groups, createFeatureGroupLabelPredicate(CLASS_LEVEL_GROUP_LABEL));
+        assertThat(group2.contains(TestFeatures.FEATURE), is(true));
+    }
+
+    private Predicate<FeatureGroup> createFeatureGroupLabelPredicate(final String label) {
+        return new Predicate<FeatureGroup>() {
+            @Override
+            public boolean apply(FeatureGroup group) {
+                return group.getLabel().equals(label);
+            }
+        };
+    }
+}

--- a/core/src/test/java/org/togglz/core/util/FeatureAnnotationsTest.java
+++ b/core/src/test/java/org/togglz/core/util/FeatureAnnotationsTest.java
@@ -1,13 +1,53 @@
 package org.togglz.core.util;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
 import static junit.framework.Assert.assertEquals;
 
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Set;
 import org.junit.Test;
 import org.togglz.core.Feature;
 import org.togglz.core.annotation.EnabledByDefault;
+import org.togglz.core.annotation.FeatureGroup;
 import org.togglz.core.annotation.Label;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 
 public class FeatureAnnotationsTest {
+
+    @FeatureGroup
+    @Label("Class Level Group Label")
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface ClassLevelGroup {
+    }
+
+    @ClassLevelGroup
+    private static enum MyFeature implements Feature {
+
+        @Label("Some feature with a label")
+        FEATURE_WITH_LABEL,
+
+        // no label annotation
+        FEATURE_WITHOUT_LABEL,
+
+        @EnabledByDefault
+        FEATURE_ENABLED_BY_DEFAULT;
+
+    }
+
+    private static enum MyFeature2 implements Feature {
+
+        FEATURE_WITH_NO_ANNOTATIONS
+
+    }
 
     @Test
     public void testGetLabel() {
@@ -26,17 +66,50 @@ public class FeatureAnnotationsTest {
 
     }
 
-    private static enum MyFeature implements Feature {
+    @Test
+    public void getAnnotationsWillReturnBothFieldAndClassLevelAnnotations() throws Exception {
+        Set<Annotation> result = FeatureAnnotations.getAnnotations(MyFeature.FEATURE_ENABLED_BY_DEFAULT);
 
-        @Label("Some feature with a label")
-        FEATURE_WITH_LABEL,
+        assertThat(result, notNullValue());
+        assertThat(result.size(), is(2));
 
-        // no label annotation
-        FEATURE_WITHOUT_LABEL,
-
-        @EnabledByDefault
-        FEATURE_ENABLED_BY_DEFAULT;
-
+        // verify both EnabledByDefault and ClassLevelGroup are there
+        Iterables.find(result, createAnnotationTypePredicate(EnabledByDefault.class));
+        Iterables.find(result, createAnnotationTypePredicate(ClassLevelGroup.class));
     }
 
+    @Test
+    public void getAnnotationsWillReturnEmptySetWhenThereAreNoAnnotations() throws Exception {
+        Set<Annotation> result = FeatureAnnotations.getAnnotations(MyFeature2.FEATURE_WITH_NO_ANNOTATIONS);
+
+        assertThat(result, notNullValue());
+        assertThat(result.size(), is(0));
+    }
+
+    private Predicate<Annotation> createAnnotationTypePredicate(final Class<? extends Annotation> annotationType) {
+        return new Predicate<Annotation>() {
+            @Override
+            public boolean apply(Annotation annotation) {
+                return annotation.annotationType().equals(annotationType);
+            }
+        };
+    }
+
+    @Test
+    public void getAnnotationWillReturnFieldLevelAnnotation() throws Exception {
+        EnabledByDefault result = FeatureAnnotations.getAnnotation(MyFeature.FEATURE_ENABLED_BY_DEFAULT, EnabledByDefault.class);
+        assertThat(result, notNullValue());
+    }
+
+    @Test
+    public void getAnnotationWillReturnClassLevelAnnotation() throws Exception {
+        ClassLevelGroup result = FeatureAnnotations.getAnnotation(MyFeature.FEATURE_ENABLED_BY_DEFAULT, ClassLevelGroup.class);
+        assertThat(result, notNullValue());
+    }
+
+    @Test
+    public void getAnnotationWillReturnNullWhenAnnotationDoesNotExist() throws Exception {
+        Label result = FeatureAnnotations.getAnnotation(MyFeature.FEATURE_ENABLED_BY_DEFAULT, Label.class);
+        assertThat(result, nullValue());
+    }
 }


### PR DESCRIPTION
- modify FeatureAnnotations getAnnotations() and getAnnotation() to consider type level annotations (not just field level annotations)
- modify FeatureAnnotations getAnnotations() signature to return Set instead of an array and also to return empty Set instead of null in case there are no annotations
- increase unit test coverage
