### PR TITLE
Better exception handling in FeatureProxyInvocationHandler

### DIFF
--- a/core/src/main/java/org/togglz/core/proxy/FeatureProxyInvocationHandler.java
+++ b/core/src/main/java/org/togglz/core/proxy/FeatureProxyInvocationHandler.java
@@ -1,6 +1,7 @@
 package org.togglz.core.proxy;
 
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import org.togglz.core.Feature;
@@ -37,7 +38,12 @@ public class FeatureProxyInvocationHandler implements InvocationHandler {
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         Object target = featureManager.isActive(feature) ? active : inactive;
-        return method.invoke(target, args);
+        try {
+        	return method.invoke(target, args);
+        } catch (InvocationTargetException ex) {
+        	throw ex.getCause();
+        }
+        
     }
 
     public Feature getFeature() {


### PR DESCRIPTION
Hi, 

When a proxied interface throws a checked exception the InvocationHandler was throwing the "wrong" exception.  The checked exception was wrapped into a InvocationTargetException.  I simply added a catch block around invoke call.  Have a look at the following article for more details:
http://amitstechblog.wordpress.com/2011/07/24/java-proxies-and-undeclaredthrowableexception/

By the way, we are using Togglz and lovinig it!

Thanks,
Alex
