### PR TITLE
Add FeatureRuntimeAttributes

### DIFF
--- a/core/src/main/java/org/togglz/core/manager/DefaultFeatureManager.java
+++ b/core/src/main/java/org/togglz/core/manager/DefaultFeatureManager.java
@@ -8,9 +8,11 @@ import org.togglz.core.Feature;
 import org.togglz.core.activation.ActivationStrategyProvider;
 import org.togglz.core.metadata.EmptyFeatureMetaData;
 import org.togglz.core.metadata.FeatureMetaData;
+import org.togglz.core.metadata.FeatureRuntimeAttributes;
 import org.togglz.core.repository.FeatureState;
 import org.togglz.core.repository.StateRepository;
 import org.togglz.core.spi.ActivationStrategy;
+import org.togglz.core.spi.ActivationStrategyWithRuntimeAttributes;
 import org.togglz.core.spi.FeatureProvider;
 import org.togglz.core.user.FeatureUser;
 import org.togglz.core.user.UserProvider;
@@ -61,6 +63,11 @@ public class DefaultFeatureManager implements FeatureManager {
 
     @Override
     public boolean isActive(Feature feature) {
+        return isActive(feature, new FeatureRuntimeAttributes());
+    }
+
+    @Override
+    public boolean isActive(Feature feature, FeatureRuntimeAttributes attributes) {
 
         Validate.notNull(feature, "feature is required");
 
@@ -83,6 +90,10 @@ public class DefaultFeatureManager implements FeatureManager {
             // check the selected strategy
             for (ActivationStrategy strategy : strategyProvider.getActivationStrategies()) {
                 if (strategy.getId().equalsIgnoreCase(strategyId)) {
+                    if (ActivationStrategyWithRuntimeAttributes.class.isInstance(strategy)) {
+                        return ActivationStrategyWithRuntimeAttributes.class.cast(strategy)
+                            .isActive(state, user, attributes);
+                    }
                     return strategy.isActive(state, user);
                 }
             }
@@ -90,7 +101,6 @@ public class DefaultFeatureManager implements FeatureManager {
 
         // if the strategy was not found, the feature should be off
         return false;
-
     }
 
     @Override

--- a/core/src/main/java/org/togglz/core/manager/FeatureManager.java
+++ b/core/src/main/java/org/togglz/core/manager/FeatureManager.java
@@ -7,6 +7,7 @@ import org.togglz.core.Feature;
 import org.togglz.core.activation.ActivationStrategyProvider;
 import org.togglz.core.context.FeatureContext;
 import org.togglz.core.metadata.FeatureMetaData;
+import org.togglz.core.metadata.FeatureRuntimeAttributes;
 import org.togglz.core.repository.FeatureState;
 import org.togglz.core.repository.StateRepository;
 import org.togglz.core.spi.ActivationStrategy;
@@ -55,8 +56,19 @@ public interface FeatureManager {
     boolean isActive(Feature feature);
 
     /**
-     * Get the current feature user. This method will internally use the configured {@link UserProvider} to obtain the
-     * user.
+     * Checks whether the supplied feature is active or not. Please note that this method will internally use the
+     * {@link UserProvider} to obtain the currently acting user as it may be relevant if the feature is enabled only for
+     * specific set of users. The supplied attributes may be relevant to check if the feature is enabled only in certain
+     * situations not specific to the user.
+     * 
+     * @param feature The feature to check
+     * @param attributes Attributes associated to the feature needed to check if it is active
+     * @return <code>true</code> if the feature is active, <code>false</code> otherwise
+     */
+    boolean isActive(Feature feature, FeatureRuntimeAttributes attributes);
+
+    /**
+     * Get the current feature user. This method will internally use the configured {@link UserProvider} to obtain the user.
      * 
      * @return The current {@link FeatureUser} or null if the {@link UserProvider} didn't return any result.
      */
@@ -64,8 +76,8 @@ public interface FeatureManager {
 
     /**
      * Returns the {@link FeatureState} for the specified feature. This state represents the current configuration of the
-     * feature and is typically persisted by a {@link StateRepository} across JVM restarts. The state includes whether
-     * the feature is enabled or disabled and the use list.
+     * feature and is typically persisted by a {@link StateRepository} across JVM restarts. The state includes whether the
+     * feature is enabled or disabled and the use list.
      * 
      * @param feature The feature to get the state for
      * @return The current state of the feature, never <code>null</code>.
@@ -82,6 +94,7 @@ public interface FeatureManager {
 
     /**
      * Provides access to the {@link ActivationStrategy} list known by the manager
+     * 
      * @return list of {@link ActivationStrategy}
      */
     List<ActivationStrategy> getActivationStrategies();

--- a/core/src/main/java/org/togglz/core/manager/LazyResolvingFeatureManager.java
+++ b/core/src/main/java/org/togglz/core/manager/LazyResolvingFeatureManager.java
@@ -7,6 +7,7 @@ import org.togglz.core.Feature;
 import org.togglz.core.activation.ActivationStrategyProvider;
 import org.togglz.core.context.FeatureContext;
 import org.togglz.core.metadata.FeatureMetaData;
+import org.togglz.core.metadata.FeatureRuntimeAttributes;
 import org.togglz.core.repository.FeatureState;
 import org.togglz.core.spi.ActivationStrategy;
 import org.togglz.core.user.FeatureUser;
@@ -42,6 +43,11 @@ public class LazyResolvingFeatureManager implements FeatureManager {
     @Override
     public boolean isActive(Feature feature) {
         return getDelegate().isActive(feature);
+    }
+
+    @Override
+    public boolean isActive(Feature feature, FeatureRuntimeAttributes attributes) {
+        return getDelegate().isActive(feature, attributes);
     }
 
     @Override

--- a/core/src/main/java/org/togglz/core/metadata/FeatureRuntimeAttributes.java
+++ b/core/src/main/java/org/togglz/core/metadata/FeatureRuntimeAttributes.java
@@ -1,0 +1,60 @@
+package org.togglz.core.metadata;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Runtime attributes not related to a {@link org.togglz.core.user.FeatureUser} Used to decide the activation of a feature in a
+ * {@link org.togglz.core.spi.ActivationStrategy}
+ * 
+ * @author Fabien Chaillou
+ */
+public class FeatureRuntimeAttributes {
+
+    private final Map<String, Object> attributes;
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public FeatureRuntimeAttributes() {
+        this.attributes = new LinkedHashMap<String, Object>();
+    }
+
+    protected FeatureRuntimeAttributes(Map<String, Object> attributes) {
+        this.attributes = new LinkedHashMap<String, Object>(attributes);
+    }
+
+    public void addAttribute(String name, Object value) {
+        attributes.put(name, value);
+    }
+
+    public Map<String, Object> getAttributes() {
+        return Collections.unmodifiableMap(attributes);
+    }
+
+    public Object getAttribute(String name) {
+        return attributes.get(name);
+    }
+
+    public <T> T getAttribute(String name, Class<T> attributeClass) {
+        return attributeClass.cast(getAttribute(name));
+    }
+
+    private static class Builder {
+        private final Map<String, Object> attributes = new LinkedHashMap<String, Object>();
+
+        public Builder withAttribute(String name, Object value) {
+            attributes.put(name, value);
+            return this;
+        }
+
+        public FeatureRuntimeAttributes build() {
+            FeatureRuntimeAttributes featureRuntimeAttributes = new FeatureRuntimeAttributes(attributes);
+            attributes.clear();
+            return featureRuntimeAttributes;
+        }
+    }
+
+}

--- a/core/src/main/java/org/togglz/core/spi/ActivationStrategyWithRuntimeAttributes.java
+++ b/core/src/main/java/org/togglz/core/spi/ActivationStrategyWithRuntimeAttributes.java
@@ -1,0 +1,31 @@
+package org.togglz.core.spi;
+
+import org.togglz.core.metadata.FeatureRuntimeAttributes;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.user.FeatureUser;
+
+/**
+ * This interface represents a custom strategy for deciding whether a feature is active or not. It extends the basic strategy to
+ * allow to decide if the Feature is enabled depending on runtime attributes not tied to the current user.
+ * 
+ * @author Fabien Chaillou
+ */
+public interface ActivationStrategyWithRuntimeAttributes extends ActivationStrategy {
+
+    /**
+     * This method is responsible to decide whether a feature is active or not. The implementation can use the custom
+     * configuration parameters of the strategy stored in the feature state, information from the currently acting user and
+     * informations from the runtimesAttributes to find a decision.
+     * 
+     * @param featureState The feature state which represents the current configuration of the feature. The implementation of
+     *        the method typically uses {@link org.togglz.core.repository.FeatureState#getParameter(String)} to access custom
+     *        configuration paramater values.
+     * @param user The user for which to decide whether the feature is active. May be <code>null</code> if the user could not be
+     *        identified by the {@link org.togglz.core.user.UserProvider}.
+     * @param runtimeAttributes Runtime attributes not associated to the user for which to decide if the feature is active.
+     * 
+     * 
+     * @return <code>true</code> if the feature should be active, else <code>false</code>
+     */
+    boolean isActive(FeatureState featureState, FeatureUser user, FeatureRuntimeAttributes runtimeAttributes);
+}

--- a/testing/src/main/java/org/togglz/testing/TestFeatureManager.java
+++ b/testing/src/main/java/org/togglz/testing/TestFeatureManager.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import org.togglz.core.Feature;
 import org.togglz.core.manager.FeatureManager;
 import org.togglz.core.metadata.FeatureMetaData;
+import org.togglz.core.metadata.FeatureRuntimeAttributes;
 import org.togglz.core.metadata.enums.EnumFeatureMetaData;
 import org.togglz.core.repository.FeatureState;
 import org.togglz.core.spi.ActivationStrategy;
@@ -51,6 +52,11 @@ public class TestFeatureManager implements FeatureManager {
     @Override
     public boolean isActive(Feature feature) {
         return activeFeatures.contains(feature.name());
+    }
+
+    @Override
+    public boolean isActive(Feature feature, FeatureRuntimeAttributes attributes) {
+        return isActive(feature);
     }
 
     @Override

--- a/testing/src/main/java/org/togglz/testing/fallback/FallbackTestFeatureManager.java
+++ b/testing/src/main/java/org/togglz/testing/fallback/FallbackTestFeatureManager.java
@@ -8,6 +8,7 @@ import org.togglz.core.Feature;
 import org.togglz.core.manager.FeatureManager;
 import org.togglz.core.metadata.EmptyFeatureMetaData;
 import org.togglz.core.metadata.FeatureMetaData;
+import org.togglz.core.metadata.FeatureRuntimeAttributes;
 import org.togglz.core.repository.FeatureState;
 import org.togglz.core.spi.ActivationStrategy;
 import org.togglz.core.user.FeatureUser;
@@ -38,6 +39,11 @@ public class FallbackTestFeatureManager implements FeatureManager {
 
     @Override
     public boolean isActive(Feature feature) {
+        return true;
+    }
+
+    @Override
+    public boolean isActive(Feature feature, FeatureRuntimeAttributes attributes) {
         return true;
     }
 


### PR DESCRIPTION
FeatureRuntimeAttributes are attributes transmitted to ActivationStrategy that are interested in it by implementing ActivationStrategyWithRuntimeAttributes instead of the base ActivationStrategy interface.
It allows the strategy to decide whether the feature should be enabled or not depending on attributes that are not user specific and can change at runtime.

In my company, we are starting to use togglz on backend application with no user and we need to be able to activate/deactive features depending on runtime attributes.
To be more precise, we are processing requests in Camel and we will want to have the feature active depending on data which is part of the request.

For that, we are proposing to introduce FeatureRuntimeAttributes which are attributes transmitted to the ActivationStrategy directly from the feature.

In our case, we envision to pass directly the data from the place where we want to check for the feature activation.

I might need to add some tests to show more in detail how we think about it and see with you if this could be mergeable or the changes you would like.

Thank you
Fabien
