### PR TITLE
"Fluidfying" Togglz Console main layout using Bootstrap fluid grid system

### DIFF
--- a/console/src/main/resources/org/togglz/console/template.html
+++ b/console/src/main/resources/org/togglz/console/template.html
@@ -9,14 +9,14 @@
     <script src="bootstrap.js"></script>
   </head>
   <body>
-    <div class="container">
+    <div class="container-fluid">
       <div class="page-header">
         <h1>Togglz</h1>
         ${if displayName}
         <h2>${displayName}</h2>
         ${end}
       </div>
-      <div class="row">
+      <div class="row-fluid">
         <div class="span12">
           ${content}
         </div>


### PR DESCRIPTION
When adding the Togglz Console to Google AppEngine's Admin Dashboard the page is loaded within an iframe, a horizontal scrollbar is shown and the gear buttons are hidden on the right.
Making the layout fluid solves the issue.
