### PR TITLE
Add vhost name based activation strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 target/
 bin/
 generated-sources/
+.idea/
 *.iml
 *.ipr
 test-output

--- a/appengine/pom.xml
+++ b/appengine/pom.xml
@@ -66,13 +66,10 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
-      <scope>test</scope>
+      <artifactId>mockito-core</artifactId>
     </dependency>
 
   </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,15 +28,11 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>1.5.0</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.9.0</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,20 @@
         <version>3.1.0.Final</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>1.6.0</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>1.9.5</version>
+        <scope>test</scope>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -26,6 +26,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.togglz</groupId>
       <artifactId>togglz-test-harness</artifactId>
       <scope>test</scope>

--- a/servlet/src/main/java/org/togglz/servlet/activation/VhostNameActivationStrategy.java
+++ b/servlet/src/main/java/org/togglz/servlet/activation/VhostNameActivationStrategy.java
@@ -1,0 +1,65 @@
+package org.togglz.servlet.activation;
+
+import org.togglz.core.activation.Parameter;
+import org.togglz.core.activation.ParameterBuilder;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.spi.ActivationStrategy;
+import org.togglz.core.user.FeatureUser;
+import org.togglz.core.util.Strings;
+import org.togglz.servlet.util.HttpServletRequestHolder;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+/**
+ * Activation strategy that will use the Virtual Host (vhost) server name used in the request to decide if the feature
+ * is active or not.
+ *
+ * This strategy can be useful when given service instance is available through two different Virtual Host names
+ * (vhosts like www.example.com and beta.example.com) each with different features enabled.
+ *
+ * @author Marcin Zajączkowski, 2014-04-28
+ */
+public class VhostNameActivationStrategy implements ActivationStrategy {
+
+    //Visible for testing
+    static final String ID = "vhost";
+    static final String PARAM_VHOST_NAMES = "vhosts";
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public String getName() {
+        return "Virtual Host (vhost) names";
+    }
+
+    @Override
+    public boolean isActive(FeatureState featureState, FeatureUser user) {
+        HttpServletRequest request = getServletRequest();
+        if (request != null) {
+           String allowedServerNamesParam = featureState.getParameter(PARAM_VHOST_NAMES);
+           List<String> allowedServerNames = Strings.splitAndTrim(allowedServerNamesParam, "[\\s,]+");
+
+           //TODO: This could support a wildcard domain name matching like *.beta.example.com
+           return allowedServerNames.contains(request.getServerName());
+        }
+        return false;
+    }
+
+    //Visible for testing
+    HttpServletRequest getServletRequest() {
+        return HttpServletRequestHolder.get();
+    }
+
+    @Override
+    public Parameter[] getParameters() {
+        return new Parameter[] {
+                ParameterBuilder.create(PARAM_VHOST_NAMES).label("vhost names")
+                    .description("A comma-separated list of Virtual Host (vhost) server names used in request " +
+                            "for which the feature should be active.")
+        };
+    }
+}

--- a/servlet/src/main/resources/META-INF/services/org.togglz.core.spi.ActivationStrategy
+++ b/servlet/src/main/resources/META-INF/services/org.togglz.core.spi.ActivationStrategy
@@ -1,1 +1,2 @@
 org.togglz.servlet.activation.ClientIpActivationStrategy
+org.togglz.servlet.activation.VhostNameActivationStrategy

--- a/servlet/src/test/java/org/togglz/servlet/activation/VhostNameActivationStrategyTest.java
+++ b/servlet/src/test/java/org/togglz/servlet/activation/VhostNameActivationStrategyTest.java
@@ -1,0 +1,82 @@
+package org.togglz.servlet.activation;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.togglz.core.Feature;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.user.FeatureUser;
+import org.togglz.core.user.SimpleFeatureUser;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class VhostNameActivationStrategyTest {
+
+    private static final String MATCHING_VHOST_NAME = "enabled.example.com";
+    private static final String DIFFERENT_VHOST_NAME = "disabled.example.com";
+
+    private VhostNameActivationStrategy strategySpy;
+    private FeatureUser user;
+    private FeatureState state;
+
+    @Before
+    public void init() {
+        HttpServletRequest requestMock = mock(HttpServletRequest.class);
+        given(requestMock.getServerName()).willReturn(MATCHING_VHOST_NAME);
+
+        strategySpy = spy(new VhostNameActivationStrategy());
+        willReturn(requestMock).given(strategySpy).getServletRequest();
+
+        user = new SimpleFeatureUser("ea", false);
+        state = new FeatureState(TestFeature.TEST_FEATURE).enable().setStrategyId(VhostNameActivationStrategy.ID);
+    }
+
+    @Test
+    public void shouldReturnFalseForEmptyDomainList() {
+        //when
+        boolean active = strategySpy.isActive(state, user);
+        //then
+        assertThat(active).isFalse();
+    }
+
+    @Test
+    public void shouldReturnTrueForFeatureOnMatchingDomainName() {
+        //given
+        state.setParameter(VhostNameActivationStrategy.PARAM_VHOST_NAMES, MATCHING_VHOST_NAME);
+        //when
+        boolean active = strategySpy.isActive(state, user);
+        //then
+        assertThat(active).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseForFeatureOnDifferentDomainName() {
+        //given
+        state.setParameter(VhostNameActivationStrategy.PARAM_VHOST_NAMES, DIFFERENT_VHOST_NAME);
+        //when
+        boolean active = strategySpy.isActive(state, user);
+        //then
+        assertThat(active).isFalse();
+    }
+
+    @Test
+    public void shouldReturnTrueForFeatureOnMatchingOneDomainNameFromDomainList() {
+        //given
+        state.setParameter(VhostNameActivationStrategy.PARAM_VHOST_NAMES,
+                format("%s,%s", MATCHING_VHOST_NAME, DIFFERENT_VHOST_NAME));
+        //when
+        boolean active = strategySpy.isActive(state, user);
+        //then
+        assertThat(active).isTrue();
+    }
+
+    private enum TestFeature implements Feature {
+        TEST_FEATURE
+    }
+}

--- a/spring-security/pom.xml
+++ b/spring-security/pom.xml
@@ -14,7 +14,6 @@
 
   <properties>
       <!-- unit testing dependencies -->
-      <mockito.version>1.9.5</mockito.version>
       <powermock.version>1.5.3</powermock.version>
   </properties>
 
@@ -34,9 +33,7 @@
 
     <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>${mockito.version}</version>
-        <scope>test</scope>
+        <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
         <groupId>org.powermock</groupId>

--- a/test-harness/pom.xml
+++ b/test-harness/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>1.5.0</version>
+      <scope>compile</scope>
     </dependency>
 
     <!-- Arquillian -->


### PR DESCRIPTION
The activation strategy that will use the Virtual Host (vhost) server name
used in the request to decide if the feature is active or not.
This strategy can be useful when given service instance is available through
two different Virtual Host names (vhosts like www.example.com and
beta.example.com) each with different features enabled.
By the way test dependencies update and unification.

I left one TODO - support for wildcard in domain name (like *.beta.example.com).
I don't use it and it would be rather rarely used. Nevertheless, if there was a demand
for this feature I could implement it.

Btw, I had problem with a name for this strategy. The current one sounded sensible
for my colleagues, but maybe you will have an idea for a better (more meaningful) one.
