### PR TITLE
Cache Repository: Don't reset the featureState if the delegate return null and we have an expired state

### DIFF
--- a/core/src/main/java/org/togglz/core/repository/cache/CachingStateRepository.java
+++ b/core/src/main/java/org/togglz/core/repository/cache/CachingStateRepository.java
@@ -75,6 +75,10 @@ public class CachingStateRepository implements StateRepository {
 
         // no cache hit
         FeatureState featureState = delegate.getFeatureState(feature);
+		if (featureState == null && entry != null) {
+			// Return the cache entry if exist even if expired
+			return entry.getState() != null ? entry.getState().copy() : null;
+		}
 
         // cache the result (may be null)
         cache.put(feature.name(), new CacheEntry(featureState != null ? featureState.copy() : null));


### PR DESCRIPTION
Hello,

In our environment we are using a CachingStateRepository on top of a JDBCStateRepository.
We have some issues with our database connections and it brought up that if the JDBC repository fails then the Caching repository will remove the previous value from its cache and replace it with null.

So if the feature was enabled then when the JDBCStateRepository fails we will returns as if the feature was disabled.

What i propose instead is that we reuse the cached state even if it is expired. The next time the cache repository will be hit, we will requiry the delegate because the entry is still expired. (I don't see a way where the delegate state would change without being know by the CachingStateRepository)
