### PR TITLE
JDBC Repository should propagate any exception from the database.

### DIFF
--- a/core/src/main/java/org/togglz/core/repository/jdbc/JDBCStateRepository.java
+++ b/core/src/main/java/org/togglz/core/repository/jdbc/JDBCStateRepository.java
@@ -21,12 +21,15 @@ import org.togglz.core.util.Strings;
 
 /**
  * <p>
- * This repository implementation can be used to store the feature state in SQL database using the standard JDBC API.
+ * This repository implementation can be used to store the feature state in SQL
+ * database using the standard JDBC API.
  * </p>
  * 
  * <p>
- * {@link JDBCStateRepository} stores the feature state in a single database table. You can choose the name of this table using
- * a constructor argument. If the repository doesn't find the required table in the database, it will automatically create it.
+ * {@link JDBCStateRepository} stores the feature state in a single database
+ * table. You can choose the name of this table using a constructor argument. If
+ * the repository doesn't find the required table in the database, it will
+ * automatically create it.
  * </p>
  * 
  * <p>
@@ -35,9 +38,9 @@ import org.togglz.core.util.Strings;
  * 
  * <pre>
  * CREATE TABLE &lt;table&gt; (
- *   FEATURE_NAME VARCHAR(100) PRIMARY KEY, 
- *   FEATURE_ENABLED INTEGER, 
- *   STRATEGY_ID VARCHAR(200), 
+ *   FEATURE_NAME VARCHAR(100) PRIMARY KEY,
+ *   FEATURE_ENABLED INTEGER,
+ *   STRATEGY_ID VARCHAR(200),
  *   STRATEGY_PARAMS VARCHAR(2000)
  * )
  * </pre>
@@ -47,25 +50,19 @@ import org.togglz.core.util.Strings;
  * </p>
  * 
  * <pre>
- * StateRepository repository = JDBCStateRepository.newBuilder(dataSource)
- *     .tableName(&quot;features&quot;)
- *     .createTable(false)
- *     .serializer(DefaultMapSerializer.singleline())
- *     .noCommit(true)
- *     .build();
+ * StateRepository repository = JDBCStateRepository.newBuilder(dataSource).tableName(&quot;features&quot;).createTable(false).serializer(DefaultMapSerializer.singleline()).noCommit(true).build();
  * </pre>
  * 
  * <p>
- * Please note that the structure of the database table changed with version 2.0.0 because of the new extensible activation
- * strategy mechanism. The table structure will be automatically migrated to the new format.
+ * Please note that the structure of the database table changed with version
+ * 2.0.0 because of the new extensible activation strategy mechanism. The table
+ * structure will be automatically migrated to the new format.
  * </p>
  * 
  * @author Christian Kaltepoth
  * 
  */
 public class JDBCStateRepository implements StateRepository {
-
-    private final Log log = LogFactory.getLog(JDBCStateRepository.class);
 
     private final DataSource dataSource;
 
@@ -76,58 +73,73 @@ public class JDBCStateRepository implements StateRepository {
     private final boolean noCommit;
 
     /**
-     * Constructor of {@link JDBCStateRepository}. A database table called <code>TOGGLZ</code> will be created automatically for
-     * you.
-     * 
-     * @param dataSource The JDBC {@link DataSource} to obtain connections from
-     * @see #JDBCFeatureStateRepository(DataSource, String)
-     */
+	 * Constructor of {@link JDBCStateRepository}. A database table called
+	 * <code>TOGGLZ</code> will be created automatically for you.
+	 * 
+	 * @param dataSource
+	 *            The JDBC {@link DataSource} to obtain connections from
+	 * @see #JDBCFeatureStateRepository(DataSource, String)
+	 */
     public JDBCStateRepository(DataSource dataSource) {
         this(new Builder(dataSource));
     }
 
     /**
-     * Constructor of {@link JDBCStateRepository}. The database table will be created automatically for you.
-     * 
-     * @param dataSource The JDBC {@link DataSource} to obtain connections from
-     * @param tableName The name of the database table to use
-     */
+	 * Constructor of {@link JDBCStateRepository}. The database table will be
+	 * created automatically for you.
+	 * 
+	 * @param dataSource
+	 *            The JDBC {@link DataSource} to obtain connections from
+	 * @param tableName
+	 *            The name of the database table to use
+	 */
     public JDBCStateRepository(DataSource dataSource, String tableName) {
         this(new Builder(dataSource).tableName(tableName));
     }
 
     /**
-     * Constructor of {@link JDBCStateRepository}.
-     * 
-     * @param dataSource The JDBC {@link DataSource} to obtain connections from
-     * @param tableName The name of the database table to use
-     * @param createTable If set to <code>true</code>, the table will be automatically created if it is missing
-     * @deprecated use {@link JDBCStateRepository#newBuilder(DataSource)} to create a builder that can be used to configure all
-     *             aspects of the repository in a fluent way
-     */
+	 * Constructor of {@link JDBCStateRepository}.
+	 * 
+	 * @param dataSource
+	 *            The JDBC {@link DataSource} to obtain connections from
+	 * @param tableName
+	 *            The name of the database table to use
+	 * @param createTable
+	 *            If set to <code>true</code>, the table will be automatically
+	 *            created if it is missing
+	 * @deprecated use {@link JDBCStateRepository#newBuilder(DataSource)} to
+	 *             create a builder that can be used to configure all aspects of
+	 *             the repository in a fluent way
+	 */
     @Deprecated
     public JDBCStateRepository(DataSource dataSource, String tableName, boolean createTable) {
         this(new Builder(dataSource).tableName(tableName).createTable(createTable));
     }
 
     /**
-     * Constructor of {@link JDBCStateRepository}.
-     * 
-     * @param dataSource The JDBC {@link DataSource} to obtain connections from
-     * @param tableName The name of the database table to use
-     * @param createTable If set to <code>true</code>, the table will be automatically created if it is missing
-     * @param serializer The {@link MapSerializer} for storing parameters
-     * @deprecated use {@link JDBCStateRepository#newBuilder(DataSource)} to create a builder that can be used to configure all
-     *             aspects of the repository in a fluent way
-     */
+	 * Constructor of {@link JDBCStateRepository}.
+	 * 
+	 * @param dataSource
+	 *            The JDBC {@link DataSource} to obtain connections from
+	 * @param tableName
+	 *            The name of the database table to use
+	 * @param createTable
+	 *            If set to <code>true</code>, the table will be automatically
+	 *            created if it is missing
+	 * @param serializer
+	 *            The {@link MapSerializer} for storing parameters
+	 * @deprecated use {@link JDBCStateRepository#newBuilder(DataSource)} to
+	 *             create a builder that can be used to configure all aspects of
+	 *             the repository in a fluent way
+	 */
     @Deprecated
     public JDBCStateRepository(DataSource dataSource, String tableName, boolean createTable, MapSerializer serializer) {
-        this(new Builder(dataSource).tableName(tableName).createTable(createTable).serializer(serializer));
+		this(new Builder(dataSource).tableName(tableName).createTable(createTable).serializer(serializer));
     }
 
     /**
      * Constructor of {@link JDBCStateRepository}.
-     * 
+     *
      * @param dataSource The JDBC {@link DataSource} to obtain connections from
      * @param tableName The name of the database table to use
      * @param createTable If set to <code>true</code>, the table will be automatically created if it is missing
@@ -171,12 +183,12 @@ public class JDBCStateRepository implements StateRepository {
                     updater.migrateToVersion2();
                 }
 
-            } finally {
-                DbUtils.closeQuietly(connection);
-            }
+			} finally {
+				DbUtils.closeQuietly(connection);
+			}
 
-        } catch (SQLException e) {
-            log.error("Failed", e);
+		} catch (SQLException e) {
+            throw new IllegalStateException("Failed to migrate the database schema", e);
         }
 
     }
@@ -229,11 +241,11 @@ public class JDBCStateRepository implements StateRepository {
                 }
 
             } finally {
-                DbUtils.closeQuietly(connection);
-            }
+				DbUtils.closeQuietly(connection);
+			}
 
-        } catch (SQLException e) {
-            log.error("Failed", e);
+		} catch (SQLException e) {
+			throw new IllegalStateException("Failed to fetch the feature's state from the database", e);
         }
 
         return null;
@@ -299,10 +311,10 @@ public class JDBCStateRepository implements StateRepository {
 
             } finally {
                 DbUtils.closeQuietly(connection);
-            }
+			}
 
-        } catch (SQLException e) {
-            log.error("Failed", e);
+		} catch (SQLException e) {
+			throw new IllegalStateException("Failed to set the feature's state in the database", e);
         }
 
     }
@@ -312,10 +324,12 @@ public class JDBCStateRepository implements StateRepository {
     }
 
     /**
-     * Creates a new builder for creating a {@link JDBCStateRepository}.
-     * 
-     * @param dataSource the {@link DataSource} Togglz should use to obtain JDBC connections
-     */
+	 * Creates a new builder for creating a {@link JDBCStateRepository}.
+	 * 
+	 * @param dataSource
+	 *            the {@link DataSource} Togglz should use to obtain JDBC
+	 *            connections
+	 */
     public static Builder newBuilder(DataSource dataSource) {
         return new Builder(dataSource);
     }
@@ -332,52 +346,61 @@ public class JDBCStateRepository implements StateRepository {
         private boolean createTable = true;
 
         /**
-         * Creates a new builder for creating a {@link JDBCStateRepository}.
-         * 
-         * @param dataSource the {@link DataSource} Togglz should use to obtain JDBC connections
-         */
+		 * Creates a new builder for creating a {@link JDBCStateRepository}.
+		 * 
+		 * @param dataSource
+		 *            the {@link DataSource} Togglz should use to obtain JDBC
+		 *            connections
+		 */
         public Builder(DataSource dataSource) {
             this.dataSource = dataSource;
         }
 
         /**
-         * Sets the table name to use for the Togglz feature state table. The default name is <code>TOGGLZ</code>.
-         * 
-         * @param tableName The database table name
-         */
+		 * Sets the table name to use for the Togglz feature state table. The
+		 * default name is <code>TOGGLZ</code>.
+		 * 
+		 * @param tableName
+		 *            The database table name
+		 */
         public Builder tableName(String tableName) {
             this.tableName = tableName;
             return this;
         }
 
         /**
-         * The {@link MapSerializer} for storing parameters. By default the repository will use
-         * {@link DefaultMapSerializer#multiline()}.
-         * 
-         * @param serializer The serializer to use
-         */
+		 * The {@link MapSerializer} for storing parameters. By default the
+		 * repository will use {@link DefaultMapSerializer#multiline()}.
+		 * 
+		 * @param serializer
+		 *            The serializer to use
+		 */
         public Builder serializer(MapSerializer serializer) {
             this.serializer = serializer;
             return this;
         }
 
         /**
-         * Can be used to suppress to commit after modifying data in the repository. Can be useful if Togglz uses managed
-         * connections provided by a JEE container. The default is <code>false</code>.
-         * 
-         * @param noCommit <code>true</code> to suppress commits
-         */
+		 * Can be used to suppress to commit after modifying data in the
+		 * repository. Can be useful if Togglz uses managed connections provided
+		 * by a JEE container. The default is <code>false</code>.
+		 * 
+		 * @param noCommit
+		 *            <code>true</code> to suppress commits
+		 */
         public Builder noCommit(boolean noCommit) {
             this.noCommit = noCommit;
             return this;
         }
 
         /**
-         * If set to <code>true</code>, the table will be automatically created if it is missing. The default is
-         * <code>true</code>.
-         * 
-         * @param createTable <code>true</code> if the table should be created automatically
-         */
+		 * If set to <code>true</code>, the table will be automatically created
+		 * if it is missing. The default is <code>true</code>.
+		 * 
+		 * @param createTable
+		 *            <code>true</code> if the table should be created
+		 *            automatically
+		 */
         public Builder createTable(boolean createTable) {
             this.createTable = createTable;
             return this;


### PR DESCRIPTION
Hello,
Following my previous pull request (#90), here is another one that makes the JdbcRepository propagate the SQLException through an IllegalStateException, i agree that in the future a Runtime "StateRepositoryException" might be better.

Regards,
Fabien
