### PR TITLE
Add support for inverting sense of JSP feature test.

### DIFF
--- a/jsp/src/main/java/org/togglz/jsp/ActiveFeatureTag.java
+++ b/jsp/src/main/java/org/togglz/jsp/ActiveFeatureTag.java
@@ -26,12 +26,22 @@ public class ActiveFeatureTag extends TagSupport {
 
     @Override
     public int doStartTag() throws JspException {
+        boolean inverse = false;
+        if (name.startsWith("!")) {
+            inverse = true;
+            name = name.substring(1);
+        }
+
     	boolean isActive = isFeatureActive();
+
+        if (inverse) {
+            isActive = !isActive;
+        }
         
         if (Strings.isNotBlank(var)) {
              pageContext.setAttribute(var, isActive, PageContext.PAGE_SCOPE);
          }
-        
+
         return isActive ? Tag.EVAL_BODY_INCLUDE : Tag.SKIP_BODY;
     }
 

--- a/jsp/src/test/java/org/togglz/jsp/JspTaglibTest.java
+++ b/jsp/src/test/java/org/togglz/jsp/JspTaglibTest.java
@@ -1,10 +1,10 @@
 package org.togglz.jsp;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.IOException;
 import java.net.URL;
 
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -15,8 +15,7 @@ import org.togglz.core.manager.TogglzConfig;
 import org.togglz.test.Deployments;
 import org.togglz.test.Packaging;
 
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Arquillian.class)
 public class JspTaglibTest {
@@ -28,6 +27,7 @@ public class JspTaglibTest {
             .addClass(JspTaglibFeature.class)
             .addClass(JspTaglibConfiguration.class)
             .addAsWebResource("jsp-taglib-test.jsp")
+            .addAsWebResource("jsp-taglib-inverse-test.jsp")
             .setWebXML(Packaging.webAppDescriptor()
                 .contextParam(TogglzConfig.class.getName(), JspTaglibConfiguration.class.getName())
                 .exportAsAsset());
@@ -44,6 +44,15 @@ public class JspTaglibTest {
         assertThat(page.asText())
             .contains("Feature [ACTIVE_FEATURE] is active")
             .doesNotContain("Feature [INACTIVE_FEATURE] is active");
+    }
+
+    @Test
+    public void shouldIncludeOrExcludeBodyCorrectlyInverseCondition() throws IOException {
+        WebClient client = new WebClient();
+        HtmlPage page = client.getPage(url + "jsp-taglib-inverse-test.jsp");
+        assertThat(page.asText())
+                .contains("Feature [INACTIVE_FEATURE] is inactive")
+                .doesNotContain("Feature [ACTIVE_FEATURE] is inactive");
     }
 
 }

--- a/jsp/src/test/resources/jsp-taglib-inverse-test.jsp
+++ b/jsp/src/test/resources/jsp-taglib-inverse-test.jsp
@@ -1,0 +1,20 @@
+<!doctype html>
+<%@ taglib prefix="togglz" uri="http://togglz.org/taglib"%>
+<html>
+<body>
+
+  <p>
+    <togglz:feature name="!ACTIVE_FEATURE">
+      Feature [ACTIVE_FEATURE] is active
+    </togglz:feature>
+  </p>
+
+  <p>
+    <togglz:feature name="!INACTIVE_FEATURE">
+      Feature [INACTIVE_FEATURE] is inactive
+    </togglz:feature>
+  </p>
+
+</body>
+
+</html>


### PR DESCRIPTION
Added support to the JSP ActiveFeatureTag to conditionally include when a feature is inactive. In the tag, if the first character of the feature name is '!', then the sense of the test is inverted, so the contained markup is included when the feature is inactive.
