### PR TITLE
Fix for erratic test failure

### DIFF
--- a/core/src/test/java/org/togglz/core/repository/cache/CachingStateRepositoryTest.java
+++ b/core/src/test/java/org/togglz/core/repository/cache/CachingStateRepositoryTest.java
@@ -98,7 +98,7 @@ public class CachingStateRepositoryTest {
         // do some lookups
         for (int i = 0; i < 5; i++) {
             assertTrue(repository.getFeatureState(DummyFeature.TEST).isEnabled());
-            Thread.sleep(ttl + 1); // wait some minimal amount of time to let the cache expire
+            Thread.sleep(ttl + 30); // wait some small amount of time to let the cache expire
         }
 
         // delegate called 5 times


### PR DESCRIPTION
Bump up the sleep time to (apparently) resolve the erratic failures.