### PR TITLE
#134 Add Spring-Boot integration

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -87,6 +87,11 @@
     </dependency>
     <dependency>
       <groupId>org.togglz</groupId>
+      <artifactId>togglz-spring-boot-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.togglz</groupId>
       <artifactId>togglz-jsf</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -37,6 +37,7 @@
         <include>org.togglz:togglz-spring-core:jar:*</include>
         <include>org.togglz:togglz-spring-web:jar:*</include>
         <include>org.togglz:togglz-spring-security:jar:*</include>
+        <include>org.togglz:togglz-spring-boot-starter:jar:*</include>
         <include>org.togglz:togglz-deltaspike:jar:*</include>
         <include>org.togglz:togglz-shiro:jar:*</include>
         <include>org.togglz:togglz-jsf:jar:*</include>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
     <module>spring-core</module>
     <module>spring-web</module>
     <module>spring-security</module>
+    <module>spring-boot-starter</module>
     <module>deltaspike</module>
     <module>shiro</module>
     <module>jsf</module>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.togglz</groupId>
+    <artifactId>togglz-project</artifactId>
+    <version>2.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>togglz-spring-boot-starter</artifactId>
+  <name>Togglz - Spring Boot Starter</name>
+  <description>Togglz - Spring Boot Starter</description>
+
+  <properties>
+    <hamcrest.version>1.3</hamcrest.version>
+    <hibernate-validator.version>5.2.2.Final</hibernate-validator.version>
+    <spring-boot.version>1.3.2.RELEASE</spring-boot.version>
+    <spring-security.version>4.0.3.RELEASE</spring-security.version>
+    <thymeleaf-togglz.version>1.0.1.RELEASE</thymeleaf-togglz.version>
+  </properties>
+
+  <developers>
+    <developer>
+      <id>marceloverdijk</id>
+      <email>maceloverdijk@gmail.com</email>
+      <name>Marcel Overdijk</name>
+      <timezone>CET</timezone>
+    </developer>
+  </developers>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.togglz</groupId>
+      <artifactId>togglz-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.togglz</groupId>
+      <artifactId>togglz-console</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.togglz</groupId>
+      <artifactId>togglz-spring-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.togglz</groupId>
+      <artifactId>togglz-spring-security</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator</artifactId>
+      <version>${spring-boot.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-config</artifactId>
+      <version>${spring-security.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-web</artifactId>
+      <version>${spring-security.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.heneke.thymeleaf</groupId>
+      <artifactId>thymeleaf-extras-togglz</artifactId>
+      <version>${thymeleaf-togglz.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <version>${hibernate-validator.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/PropertiesPropertySource.java
+++ b/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/PropertiesPropertySource.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.togglz.spring.boot.autoconfigure;
+
+import org.togglz.core.repository.property.PropertySource;
+
+import java.util.*;
+
+/**
+ * {@link PropertySource} implementation for use with {@link Properties}.
+ *
+ * @author Marcel Overdijk
+ */
+public class PropertiesPropertySource implements PropertySource {
+
+    private Properties values = new Properties();
+
+    public PropertiesPropertySource(Properties properties) {
+        this.values = properties;
+    }
+
+    @Override
+    public void reloadIfUpdated() {
+        // do nothing
+    }
+
+    @Override
+    public Set<String> getKeysStartingWith(String prefix) {
+        Set<String> result = new HashSet<String>();
+        Enumeration<?> keys = values.propertyNames();
+        while (keys.hasMoreElements()) {
+            String key = keys.nextElement().toString();
+            if (key.startsWith(prefix)) {
+                result.add(key);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public String getValue(String key, String defaultValue) {
+        return values.getProperty(key, defaultValue);
+    }
+
+    @Override
+    public Editor getEditor() {
+        return new PropertiesEditor(values);
+    }
+
+    private void setValues(Properties values) {
+        this.values = values;
+    }
+
+    private class PropertiesEditor implements Editor {
+
+        private Properties newValues;
+
+        private PropertiesEditor(Properties values) {
+            newValues = new Properties();
+            newValues.putAll(values);
+        }
+
+        @Override
+        public void setValue(String key, String value) {
+            if (value != null) {
+                newValues.setProperty(key, value);
+            } else {
+                newValues.remove(key);
+            }
+        }
+
+        @Override
+        public void removeKeysStartingWith(String prefix) {
+            Iterator<Map.Entry<Object, Object>> iterator = newValues.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<Object, Object> entry = iterator.next();
+                if (entry.getKey().toString().startsWith(prefix)) {
+                    iterator.remove();
+                }
+            }
+        }
+
+        @Override
+        public void commit() {
+            setValues(newValues);
+        }
+    }
+}

--- a/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzApplicationContextBinderApplicationListener.java
+++ b/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzApplicationContextBinderApplicationListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.togglz.spring.boot.autoconfigure;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.togglz.spring.util.ContextClassLoaderApplicationContextHolder;
+
+/**
+ * {@link ApplicationListener} that binds the {@link ApplicationContext}
+ * to the Togglz {@link ContextClassLoaderApplicationContextHolder}.
+ *
+ * @author Marcel Overdijk
+ */
+public class TogglzApplicationContextBinderApplicationListener implements ApplicationListener {
+
+    @Override
+    public void onApplicationEvent(ApplicationEvent event) {
+        if (event instanceof ContextRefreshedEvent) {
+            ApplicationContext applicationContext = ((ContextRefreshedEvent) event).getApplicationContext();
+            ContextClassLoaderApplicationContextHolder.bind(applicationContext);
+        } else if (event instanceof ContextClosedEvent) {
+            ContextClassLoaderApplicationContextHolder.release();
+        }
+    }
+}

--- a/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzAutoConfiguration.java
+++ b/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzAutoConfiguration.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.togglz.spring.boot.autoconfigure;
+
+import com.github.heneke.thymeleaf.togglz.TogglzDialect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.*;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.togglz.console.TogglzConsoleServlet;
+import org.togglz.core.activation.ActivationStrategyProvider;
+import org.togglz.core.activation.DefaultActivationStrategyProvider;
+import org.togglz.core.manager.EnumBasedFeatureProvider;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.manager.FeatureManagerBuilder;
+import org.togglz.core.repository.StateRepository;
+import org.togglz.core.repository.cache.CachingStateRepository;
+import org.togglz.core.repository.composite.CompositeStateRepository;
+import org.togglz.core.repository.file.FileBasedStateRepository;
+import org.togglz.core.repository.mem.InMemoryStateRepository;
+import org.togglz.core.repository.property.PropertyBasedStateRepository;
+import org.togglz.core.repository.property.PropertySource;
+import org.togglz.core.spi.ActivationStrategy;
+import org.togglz.core.spi.FeatureProvider;
+import org.togglz.core.user.NoOpUserProvider;
+import org.togglz.core.user.UserProvider;
+import org.togglz.spring.security.SpringSecurityUserProvider;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Togglz.
+ *
+ * @author Marcel Overdijk
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "togglz", name = "enabled", matchIfMissing = true)
+@EnableConfigurationProperties(TogglzProperties.class)
+public class TogglzAutoConfiguration {
+
+    @Bean
+    public TogglzApplicationContextBinderApplicationListener togglzApplicationContextBinderApplicationListener() {
+        return new TogglzApplicationContextBinderApplicationListener();
+    }
+
+    @Configuration
+    @ConditionalOnMissingBean(FeatureProvider.class)
+    @ConditionalOnProperty(prefix = "togglz", name = "feature-enums")
+    protected static class FeatureProviderConfiguration {
+
+        @Autowired
+        private TogglzProperties properties;
+
+        @Bean
+        public FeatureProvider featureProvider() {
+            return new EnumBasedFeatureProvider(properties.getFeatureEnums());
+        }
+    }
+
+    @Configuration
+    @ConditionalOnMissingBean(FeatureManager.class)
+    protected static class FeatureManagerConfiguration {
+
+        @Autowired
+        private TogglzProperties properties;
+
+        @Bean
+        public FeatureManager featureManager(FeatureProvider featureProvider, List<StateRepository> stateRepositories, UserProvider userProvider, ActivationStrategyProvider activationStrategyProvider) {
+            StateRepository stateRepository = null;
+            if (stateRepositories.size() == 1) {
+                stateRepository = stateRepositories.get(0);
+            } else if (stateRepositories.size() > 1) {
+                stateRepository = new CompositeStateRepository(stateRepositories.toArray(new StateRepository[stateRepositories.size()]));
+            }
+            FeatureManagerBuilder featureManagerBuilder = new FeatureManagerBuilder();
+            String name = properties.getFeatureManagerName();
+            if (name != null && name.length() > 0) {
+                featureManagerBuilder.name(name);
+            }
+            featureManagerBuilder
+                    .featureProvider(featureProvider)
+                    .stateRepository(stateRepository)
+                    .userProvider(userProvider)
+                    .activationStrategyProvider(activationStrategyProvider)
+                    .build();
+            return featureManagerBuilder.build();
+        }
+    }
+
+    @Configuration
+    @ConditionalOnMissingBean(ActivationStrategyProvider.class)
+    protected static class ActivationStrategyProviderConfiguration {
+
+        @Autowired(required = false)
+        private List<ActivationStrategy> activationStrategies;
+
+        @Bean
+        public ActivationStrategyProvider activationStrategyProvider() {
+            DefaultActivationStrategyProvider provider = new DefaultActivationStrategyProvider();
+            if (activationStrategies != null && activationStrategies.size() > 0) {
+                provider.addActivationStrategies(activationStrategies);
+            }
+            return provider;
+        }
+    }
+
+    @Configuration
+    @ConditionalOnMissingBean(StateRepository.class)
+    protected static class StateRepositoryConfiguration {
+
+        @Autowired
+        private ResourceLoader resourceLoader = new DefaultResourceLoader();
+
+        @Autowired
+        private TogglzProperties properties;
+
+        @Bean
+        public StateRepository stateRepository() throws IOException {
+            StateRepository stateRepository;
+            Map<String, String> features = properties.getFeatures();
+            String featuresFile = properties.getFeaturesFile();
+            if (featuresFile != null) {
+                Resource resource = this.resourceLoader.getResource(featuresFile);
+                Integer minCheckInterval = properties.getFeaturesFileMinCheckInterval();
+                if (minCheckInterval != null) {
+                    stateRepository = new FileBasedStateRepository(resource.getFile(), minCheckInterval);
+                } else {
+                    stateRepository = new FileBasedStateRepository(resource.getFile());
+                }
+            } else if (features != null && features.size() > 0) {
+                Properties props = new Properties();
+                props.putAll(features);
+                PropertySource propertySource = new PropertiesPropertySource(props);
+                stateRepository = new PropertyBasedStateRepository(propertySource);
+            } else {
+                stateRepository = new InMemoryStateRepository();
+            }
+            if (properties.getCache().isEnabled()) {
+                stateRepository = new CachingStateRepository(stateRepository, properties.getCache().getTimeToLive(), properties.getCache().getTimeUnit());
+            }
+            return stateRepository;
+        }
+    }
+
+    @Configuration
+    @ConditionalOnMissingClass("org.springframework.security.config.annotation.web.configuration.EnableWebSecurity")
+    @ConditionalOnMissingBean(UserProvider.class)
+    protected static class UserProviderConfiguration {
+
+        @Autowired
+        private TogglzProperties properties;
+
+        @Bean
+        public UserProvider userProvider() {
+            return new NoOpUserProvider();
+        }
+    }
+
+    @Configuration
+    @ConditionalOnClass({EnableWebSecurity.class, AuthenticationEntryPoint.class})
+    @ConditionalOnMissingBean(UserProvider.class)
+    protected static class SpringSecurityUserProviderConfiguration {
+
+        @Autowired
+        private TogglzProperties properties;
+
+        @Bean
+        public UserProvider userProvider() {
+            return new SpringSecurityUserProvider(properties.getConsole().getFeatureAdminAuthority());
+        }
+    }
+
+    @Configuration
+    @ConditionalOnWebApplication
+    @ConditionalOnClass(TogglzConsoleServlet.class)
+    @ConditionalOnProperty(prefix = "togglz.console", name = "enabled", matchIfMissing = true)
+    protected static class TogglzConsoleConfiguration {
+
+        @Autowired
+        private TogglzProperties properties;
+
+        @Bean
+        public ServletRegistrationBean togglzConsole() {
+            String path = properties.getConsole().getPath();
+            String urlMapping = (path.endsWith("/") ? path + "*" : path + "/*");
+            TogglzConsoleServlet servlet = new TogglzConsoleServlet();
+            servlet.setSecured(properties.getConsole().isSecured());
+            return new ServletRegistrationBean(servlet, urlMapping);
+        }
+    }
+
+    @Configuration
+    @ConditionalOnClass(Endpoint.class)
+    @ConditionalOnMissingBean(TogglzEndpoint.class)
+    @ConditionalOnProperty(prefix = "togglz.endpoint", name = "enabled", matchIfMissing = true)
+    protected static class TogglzEndpointConfiguration {
+
+        @Autowired
+        private TogglzProperties properties;
+
+        @Bean
+        public TogglzEndpoint togglzEndpoint(FeatureManager featureManager) {
+            return new TogglzEndpoint(featureManager);
+        }
+    }
+
+    @Configuration
+    @ConditionalOnClass(TogglzDialect.class)
+    protected static class ThymeleafTogglzDialectConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean
+        public TogglzDialect togglzDialect() {
+            return new TogglzDialect();
+        }
+    }
+}

--- a/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzEndpoint.java
+++ b/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzEndpoint.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.togglz.spring.boot.autoconfigure;
+
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
+import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.Assert;
+import org.togglz.core.Feature;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.repository.FeatureState;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@link Endpoint} to expose Togglz info.
+ *
+ * @author Marcel Overdijk
+ */
+@ConfigurationProperties(prefix = "togglz.endpoint", ignoreUnknownFields = true)
+public class TogglzEndpoint extends AbstractEndpoint<List<TogglzEndpoint.TogglzFeature>> {
+
+    private final FeatureManager featureManager;
+
+    public TogglzEndpoint(FeatureManager featureManager) {
+        super("togglz");
+        Assert.notNull(featureManager, "FeatureManager must not be null");
+        this.featureManager = featureManager;
+    }
+
+    @Override
+    public List<TogglzFeature> invoke() {
+        List<TogglzFeature> features = new ArrayList<TogglzFeature>();
+        for (Feature feature : this.featureManager.getFeatures()) {
+            FeatureState featureState = this.featureManager.getFeatureState(feature);
+            features.add(new TogglzFeature(feature, featureState));
+        }
+        return features;
+    }
+
+    public static class TogglzFeature {
+
+        private String name;
+        private boolean enabled;
+        private String strategy;
+        private Map<String, String> params;
+
+        public TogglzFeature(Feature feature, FeatureState featureState) {
+            this.name = feature.name();
+            this.enabled = featureState.isEnabled();
+            this.strategy = featureState.getStrategyId();
+            this.params = featureState.getParameterMap();
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public String getStrategy() {
+            return strategy;
+        }
+
+        public Map<String, String> getParams() {
+            return params;
+        }
+    }
+}

--- a/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzProperties.java
+++ b/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzProperties.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.togglz.spring.boot.autoconfigure;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.togglz.core.Feature;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configuration properties for Togglz.
+ *
+ * @author Marcel Overdijk
+ */
+@ConfigurationProperties(prefix = "togglz", ignoreUnknownFields = true)
+public class TogglzProperties {
+
+    private boolean enabled = true;
+
+    private Class<? extends Feature>[] featureEnums;
+
+    private String featureManagerName;
+
+    private Map<String, String> features;
+
+    private String featuresFile;
+
+    private Integer featuresFileMinCheckInterval;
+
+    private Cache cache = new Cache();
+
+    @Valid
+    private Console console = new Console();
+
+    private Endpoint endpoint = new Endpoint();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public Class<? extends Feature>[] getFeatureEnums() {
+        return featureEnums;
+    }
+
+    public void setFeatureEnums(Class<? extends Feature>[] featureEnums) {
+        this.featureEnums = featureEnums;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getFeatureManagerName() {
+        return featureManagerName;
+    }
+
+    public void setFeatureManagerName(String featureManagerName) {
+        this.featureManagerName = featureManagerName;
+    }
+
+    public Map<String, String> getFeatures() {
+        return features;
+    }
+
+    public void setFeatures(Map<String, String> features) {
+        this.features = features;
+    }
+
+    public String getFeaturesFile() {
+        return featuresFile;
+    }
+
+    public void setFeaturesFile(String featuresFile) {
+        this.featuresFile = featuresFile;
+    }
+
+    public Integer getFeaturesFileMinCheckInterval() {
+        return featuresFileMinCheckInterval;
+    }
+
+    public void setFeaturesFileMinCheckInterval(Integer featuresFileMinCheckInterval) {
+        this.featuresFileMinCheckInterval = featuresFileMinCheckInterval;
+    }
+
+    public Cache getCache() {
+        return cache;
+    }
+
+    public void setCache(Cache cache) {
+        this.cache = cache;
+    }
+
+    public Console getConsole() {
+        return console;
+    }
+
+    public void setConsole(Console console) {
+        this.console = console;
+    }
+
+    public Endpoint getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(Endpoint endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public static class Cache {
+
+        private boolean enabled = false;
+
+        private long timeToLive = 0;
+
+        private TimeUnit timeUnit = TimeUnit.MILLISECONDS;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public long getTimeToLive() {
+            return timeToLive;
+        }
+
+        public void setTimeToLive(long timeToLive) {
+            this.timeToLive = timeToLive;
+        }
+
+        public TimeUnit getTimeUnit() {
+            return timeUnit;
+        }
+
+        public void setTimeUnit(TimeUnit timeUnit) {
+            this.timeUnit = timeUnit;
+        }
+    }
+
+    public static class Console {
+
+        private boolean enabled = true;
+
+        @NotNull
+        @Pattern(regexp = "/[^?#]*", message = "Path must start with /")
+        private String path = "/togglz-console";
+
+        private String featureAdminAuthority;
+
+        private boolean secured = true;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public void setPath(String path) {
+            this.path = path;
+        }
+
+        public String getFeatureAdminAuthority() {
+            return featureAdminAuthority;
+        }
+
+        public void setFeatureAdminAuthority(String featureAdminAuthority) {
+            this.featureAdminAuthority = featureAdminAuthority;
+        }
+
+        public boolean isSecured() {
+            return secured;
+        }
+
+        public void setSecured(boolean secured) {
+            this.secured = secured;
+        }
+    }
+
+    public static class Endpoint {
+
+        private String id = "togglz";
+
+        private boolean enabled = true;
+
+        private boolean sensitive = true;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public boolean isSensitive() {
+            return sensitive;
+        }
+
+        public void setSensitive(boolean sensitive) {
+            this.sensitive = sensitive;
+        }
+    }
+}

--- a/spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Auto Configure
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.togglz.spring.boot.autoconfigure.TogglzAutoConfiguration

--- a/spring-boot-starter/src/test/java/org/togglz/spring/boot/autoconfigure/TogglzAutoConfigurationTests.java
+++ b/spring-boot-starter/src/test/java/org/togglz/spring/boot/autoconfigure/TogglzAutoConfigurationTests.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.togglz.spring.boot.autoconfigure;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.togglz.core.Feature;
+import org.togglz.core.activation.Parameter;
+import org.togglz.core.context.FeatureContext;
+import org.togglz.core.manager.EnumBasedFeatureProvider;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.repository.StateRepository;
+import org.togglz.core.repository.cache.CachingStateRepository;
+import org.togglz.core.repository.file.FileBasedStateRepository;
+import org.togglz.core.repository.mem.InMemoryStateRepository;
+import org.togglz.core.repository.property.PropertyBasedStateRepository;
+import org.togglz.core.spi.ActivationStrategy;
+import org.togglz.core.spi.FeatureProvider;
+import org.togglz.core.user.FeatureUser;
+import org.togglz.core.user.UserProvider;
+import org.togglz.spring.util.ContextClassLoaderApplicationContextHolder;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link TogglzAutoConfiguration}.
+ *
+ * @author Marcel Overdijk
+ */
+public class TogglzAutoConfigurationTests {
+
+    private AnnotationConfigWebApplicationContext context;
+
+    @After
+    public void tearDown() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test
+    public void defaultTogglz() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class});
+        FeatureManager featureManager = this.context.getBean(FeatureManager.class);
+        Set<Feature> features = featureManager.getFeatures();
+        assertThat(featureManager, is(notNullValue()));
+        assertThat(features, hasSize(2));
+        assertThat(features, hasItem(MyFeatures.FEATURE_ONE));
+        assertThat(features, hasItem(MyFeatures.FEATURE_TWO));
+        assertThat(this.context.getBean(StateRepository.class), is(instanceOf(InMemoryStateRepository.class)));
+        assertThat(this.context.getBeansOfType(ServletRegistrationBean.class).size(), is(equalTo(1)));
+        assertThat(this.context.getBean(ServletRegistrationBean.class).getUrlMappings(), hasItem("/togglz-console/*"));
+        TogglzEndpoint togglzEndpoint = this.context.getBean(TogglzEndpoint.class);
+        assertThat(togglzEndpoint.getId(), is("togglz"));
+        assertThat(togglzEndpoint.isEnabled(), is(true));
+        assertThat(togglzEndpoint.isSensitive(), is(true));
+        assertThat(ContextClassLoaderApplicationContextHolder.get(), is((ApplicationContext) this.context));
+        assertThat(FeatureContext.getFeatureManager(), is(sameInstance(featureManager)));
+    }
+
+    @Test
+    public void applicationContextBinder() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class});
+        assertThat(ContextClassLoaderApplicationContextHolder.get(), is((ApplicationContext) this.context));
+    }
+
+    @Test
+    public void disabled() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class},
+                "togglz.enabled: false");
+        assertThat(this.context.getBeansOfType(FeatureManager.class).size(), is(0));
+        assertThat(this.context.getBeansOfType(ActivationStrategy.class).size(), is(0));
+        assertThat(this.context.getBeansOfType(StateRepository.class).size(), is(0));
+        assertThat(this.context.getBeansOfType(UserProvider.class).size(), is(0));
+        assertThat(this.context.getBeansOfType(ServletRegistrationBean.class).size(), is(0));
+        assertThat(this.context.getBeansOfType(TogglzEndpoint.class).size(), is(0));
+        assertThat(ContextClassLoaderApplicationContextHolder.get(), is(nullValue()));
+        try {
+            assertThat(FeatureContext.getFeatureManager(), is(nullValue()));
+            fail();
+        } catch (IllegalStateException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void featureEnums() {
+        load(new Class[]{TogglzAutoConfiguration.class},
+                "togglz.feature-enums: org.togglz.spring.boot.autoconfigure.TogglzAutoConfigurationTests.MyFeatures");
+        FeatureManager featureManager = this.context.getBean(FeatureManager.class);
+        Set<Feature> features = featureManager.getFeatures();
+        assertThat(featureManager, is(notNullValue()));
+        assertThat(features, hasSize(2));
+        assertThat(features, hasItem(MyFeatures.FEATURE_ONE));
+        assertThat(features, hasItem(MyFeatures.FEATURE_TWO));
+    }
+
+    @Test(expected = BeanCreationException.class)
+    public void featureEnumsClassNotFound() {
+        load(new Class[]{TogglzAutoConfiguration.class},
+                "togglz.feature-enums: i.dont.exist.features");
+    }
+
+    @Test
+    public void customFeatureManagerName() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class},
+                "togglz.feature-manager-name: Custom Feature Manager Name");
+        assertThat(this.context.getBean(FeatureManager.class).getName(), is("Custom Feature Manager Name"));
+    }
+
+    @Test
+    public void features() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class},
+                "togglz.features.FEATURE_ONE: true",
+                "togglz.features.FEATURE_TWO: false");
+        FeatureManager featureManager = this.context.getBean(FeatureManager.class);
+        assertThat(featureManager.isActive(MyFeatures.FEATURE_ONE), is(true));
+        assertThat(featureManager.isActive(MyFeatures.FEATURE_TWO), is(false));
+        assertThat(this.context.getBean(StateRepository.class), is(instanceOf(PropertyBasedStateRepository.class)));
+    }
+
+    @Test
+    public void featuresFile() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class},
+                "togglz.features-file: classpath:/features-file/features.properties");
+        FeatureManager featureManager = this.context.getBean(FeatureManager.class);
+        assertThat(featureManager.isActive(MyFeatures.FEATURE_ONE), is(true));
+        assertThat(featureManager.isActive(MyFeatures.FEATURE_TWO), is(false));
+        assertThat(this.context.getBean(StateRepository.class), is(instanceOf(FileBasedStateRepository.class)));
+    }
+
+    @Test
+    public void cacheEnabled() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class},
+                "togglz.cache.enabled: true");
+        assertThat(this.context.getBean(StateRepository.class), is(instanceOf(CachingStateRepository.class)));
+    }
+
+    @Test
+    public void consoleDisabled() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class},
+                "togglz.console.enabled: false");
+        assertThat(this.context.getBeansOfType(ServletRegistrationBean.class).size(), is(0));
+    }
+
+    @Test
+    public void customConsolePath() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class},
+                "togglz.console.path: /custom");
+        assertThat(this.context.getBeansOfType(ServletRegistrationBean.class).size(), is(1));
+        assertThat(this.context.getBean(ServletRegistrationBean.class).getUrlMappings(), hasItem("/custom/*"));
+    }
+
+    @Test
+    public void customConsolePathWithTrailingSlash() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class},
+                "togglz.console.path: /custom/");
+        assertThat(this.context.getBeansOfType(ServletRegistrationBean.class).size(), is(1));
+        assertThat(this.context.getBean(ServletRegistrationBean.class).getUrlMappings(), hasItems("/custom/*"));
+    }
+
+    @Test
+    public void endpointDisabled() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class},
+                "togglz.endpoint.enabled: false");
+        assertThat(this.context.getBeansOfType(TogglzEndpoint.class).size(), is(0));
+    }
+
+    @Test
+    public void endpointNotSensitive() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class},
+                "togglz.endpoint.sensitive: false");
+        assertThat(this.context.getBean(TogglzEndpoint.class).isSensitive(), is(false));
+    }
+
+    @Test
+    public void customEndpointId() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class},
+                "togglz.endpoint.id: features");
+        assertThat(this.context.getBean(TogglzEndpoint.class).getId(), is("features"));
+    }
+
+    @Test
+    public void customActivationStrategy() {
+        load(new Class[]{TogglzAutoConfiguration.class, FeatureProviderConfig.class, ActivationStrategyConfig.class});
+        FeatureManager featureManager = this.context.getBean(FeatureManager.class);
+        CustomActivationStrategy customActivationStrategy = this.context.getBean(CustomActivationStrategy.class);
+        assertThat(featureManager.getActivationStrategies().contains(customActivationStrategy), is(true));
+    }
+
+    private void load(Class<?>[] configs, String... environment) {
+        this.context = new AnnotationConfigWebApplicationContext();
+        this.context.register(configs);
+        EnvironmentTestUtils.addEnvironment(this.context, environment);
+        this.context.refresh();
+    }
+
+    protected enum MyFeatures implements Feature {
+        FEATURE_ONE,
+        FEATURE_TWO;
+    }
+
+    protected static class CustomActivationStrategy implements ActivationStrategy {
+
+        @Override
+        public String getId() {
+            return "custom";
+        }
+
+        @Override
+        public String getName() {
+            return "Custom";
+        }
+
+        @Override
+        public boolean isActive(FeatureState featureState, FeatureUser user) {
+            return true;
+        }
+
+        @Override
+        public Parameter[] getParameters() {
+            return new Parameter[0];
+        }
+    }
+
+    @Configuration
+    protected static class FeatureProviderConfig {
+
+        @Bean
+        public FeatureProvider featureProvider() {
+            return new EnumBasedFeatureProvider(MyFeatures.class);
+        }
+    }
+
+    @Configuration
+    protected static class ActivationStrategyConfig {
+
+        @Bean
+        public CustomActivationStrategy customActivationStrategy() {
+            return new CustomActivationStrategy();
+        }
+    }
+}

--- a/spring-boot-starter/src/test/java/org/togglz/spring/boot/autoconfigure/TogglzEndpointTests.java
+++ b/spring-boot-starter/src/test/java/org/togglz/spring/boot/autoconfigure/TogglzEndpointTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.togglz.spring.boot.autoconfigure;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.togglz.core.Feature;
+import org.togglz.core.manager.EnumBasedFeatureProvider;
+import org.togglz.core.spi.FeatureProvider;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link TogglzEndpoint}.
+ *
+ * @author Marcel Overdijk
+ */
+public class TogglzEndpointTests {
+
+    private AnnotationConfigApplicationContext context;
+
+    @After
+    public void tearDown() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test
+    public void invoke() throws Exception {
+        load(new Class[]{JacksonAutoConfiguration.class, TogglzAutoConfiguration.class, FeatureProviderConfig.class},
+                "togglz.features.FEATURE_ONE: true",
+                "togglz.features.FEATURE_TWO: false",
+                "togglz.features.FEATURE_TWO.strategy: release-date",
+                "togglz.features.FEATURE_TWO.param.date: 2016-07-01",
+                "togglz.features.FEATURE_TWO.param.time: 08:30:00");
+        TogglzEndpoint endpoint = this.context.getBean(TogglzEndpoint.class);
+        List<TogglzEndpoint.TogglzFeature> features = endpoint.invoke();
+        assertThat(features.size(), is(2));
+        assertThat(features.get(0).getName(), is("FEATURE_ONE"));
+        assertThat(features.get(0).isEnabled(), is(true));
+        assertThat(features.get(0).getStrategy(), is(nullValue()));
+        assertThat(features.get(0).getParams().size(), is(0));
+        assertThat(features.get(1).getName(), is("FEATURE_TWO"));
+        assertThat(features.get(1).isEnabled(), is(false));
+        assertThat(features.get(1).getStrategy(), is("release-date"));
+        assertThat(features.get(1).getParams().size(), is(2));
+        assertThat(features.get(1).getParams().get("date"), is("2016-07-01"));
+        assertThat(features.get(1).getParams().get("time"), is("08:30:00"));
+    }
+
+    private void load(Class<?>[] configs, String... environment) {
+        this.context = new AnnotationConfigApplicationContext();
+        this.context.register(configs);
+        EnvironmentTestUtils.addEnvironment(this.context, environment);
+        this.context.refresh();
+    }
+
+    protected enum MyFeatures implements Feature {
+        FEATURE_ONE,
+        FEATURE_TWO;
+    }
+
+    @Configuration
+    protected static class FeatureProviderConfig {
+
+        @Bean
+        public FeatureProvider featureProvider() {
+            return new EnumBasedFeatureProvider(MyFeatures.class);
+        }
+    }
+}

--- a/spring-boot-starter/src/test/resources/features-file/features.properties
+++ b/spring-boot-starter/src/test/resources/features-file/features.properties
@@ -1,0 +1,2 @@
+FEATURE_ONE = true
+FEATURE_TWO = false

--- a/spring-boot-starter/template.mf
+++ b/spring-boot-starter/template.mf
@@ -1,0 +1,16 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: org.togglz.spring
+Bundle-Vendor: http://www.togglz.org/
+Bundle-Version: ${osgi.bundles.version}
+Bundle-Name: ${project.name}
+Version-Patterns:
+ default;pattern="[=.=.=, =.+1.0)"
+Import-Template:
+ com.github.heneke.thymeleaf.togglz.*;version="0",
+ javax.servlet.*;version="0",
+ javax.validation.*;version="0",
+ org.springframework.*;version="[3.0,4.0)",
+ org.springframework.boot.*;version="0",
+ org.springframework.security.*;version="[2.0,4.0)",
+ org.togglz.*;version="${osgi.bundles.version:default}"


### PR DESCRIPTION
Here is the Spring Boot integration code.

We need to give some special attention to `spring-boot-starter/template.mf`:
```
..
Import-Template:
 com.github.heneke.thymeleaf.togglz.*;version="0",
 javax.servlet.*;version="0",
 javax.validation.*;version="0",
 org.springframework.*;version="[3.0,4.0)",
 org.springframework.boot.*;version="0",
 org.springframework.security.*;version="[2.0,4.0)",
 org.togglz.*;version="${osgi.bundles.version:default}"
```

I'm not familiar with this bundlor template.mf format.
I took examples from `spring-core` and `spring-security` regarding versions.
For the rest I took `"0"` as I noticed in other files as well.
Does `4.0` mean that it should be in `4.0.x` range? Spring is already in `4.2.x` range so I then wonder if template.mf contents are correct?

I will create another PR in the `togglz-site` repo containing the documentation later.