### PR TITLE
Add micro-benchmarks to JMH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,7 @@
     <module>distribution</module>
     <module>cassandra</module>
     <module>hazelcast</module>
+    <module>togglz-benchmarks</module>
   </modules>
 
   <developers>

--- a/togglz-benchmarks/README.md
+++ b/togglz-benchmarks/README.md
@@ -1,0 +1,20 @@
+Benchmarks for Togglz
+======
+
+Running the benchmarks
+---
+
+To run one of the benchmarks in your IDE, each one has a `main` method on it that will execute that single benchmark.
+ 
+To run them on a remote server, or outside of your IDE, you can package up an uber-jar that contains all of the necessary
+files to run the tests in one jar by running `mvn clean package`. The uber-jar is located in `target/togglz-benchmarks-uberjar.jar`.
+ 
+You can then run the benchmarks by executing `java -jar target/togglz-benchmarks-uberjar.jar` 
+
+
+About JMH
+---
+The benchmarks here use the ["Java Micro-benchmark Harness" (aka JMH)](http://openjdk.java.net/projects/code-tools/jmh/)
+ - widely considered to be the "gold standard" for implementing microbenchmarks on the JVM. 
+
+You can start to learn more about how JMH works by [reading through their sample tests.](http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples/)

--- a/togglz-benchmarks/pom.xml
+++ b/togglz-benchmarks/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>togglz-project</artifactId>
+        <groupId>org.togglz</groupId>
+        <version>2.3.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.togglz.benchmark</groupId>
+    <artifactId>togglz-benchmarks</artifactId>
+    <packaging>jar</packaging>
+
+    <name>JMH benchmarks for Togglz</name>
+
+    <prerequisites>
+        <maven>3.0</maven>
+    </prerequisites>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.togglz</groupId>
+            <artifactId>togglz-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jmh.version>1.12</jmh.version>
+        <javac.target>1.6</javac.target>
+        <uberjar.name>benchmarks</uberjar.name>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <compilerVersion>${javac.target}</compilerVersion>
+                    <source>${javac.target}</source>
+                    <target>${javac.target}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uberjar.name}</finalName>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.9.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.3</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.2.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.17</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/togglz-benchmarks/pom.xml
+++ b/togglz-benchmarks/pom.xml
@@ -6,6 +6,7 @@
         <artifactId>togglz-project</artifactId>
         <groupId>org.togglz</groupId>
         <version>2.3.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
     </parent>
 
     <groupId>org.togglz.benchmark</groupId>
@@ -41,7 +42,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jmh.version>1.12</jmh.version>
         <javac.target>1.6</javac.target>
-        <uberjar.name>benchmarks</uberjar.name>
+        <uberjar.name>togglz-benchmarks-uberjar</uberjar.name>
     </properties>
 
     <build>
@@ -92,47 +93,24 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <useDefaultManifestFile>true</useDefaultManifestFile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.virgo.bundlor</groupId>
+                <artifactId>org.eclipse.virgo.bundlor.maven</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundlor</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.5</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.3</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.2.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.17</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 
 </project>

--- a/togglz-benchmarks/src/main/java/org/togglz/benchmark/FeatureStateBenchmarks.java
+++ b/togglz-benchmarks/src/main/java/org/togglz/benchmark/FeatureStateBenchmarks.java
@@ -1,0 +1,122 @@
+package org.togglz.benchmark;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.togglz.core.Feature;
+import org.togglz.core.activation.ReleaseDateActivationStrategy;
+import org.togglz.core.annotation.EnabledByDefault;
+import org.togglz.core.context.FeatureContext;
+import org.togglz.core.context.StaticFeatureManagerProvider;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.manager.FeatureManagerBuilder;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.repository.mem.InMemoryStateRepository;
+import org.togglz.core.user.NoOpUserProvider;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Ryan Gardner
+ * @date 5/12/16
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode({Mode.Throughput, Mode.SampleTime, Mode.SingleShotTime})
+@Measurement(iterations = 8, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 8, time = 1, timeUnit = TimeUnit.SECONDS)
+public class FeatureStateBenchmarks {
+    FeatureManager manager;
+    boolean enabled = false;
+
+    // a simple feature for this benchmark
+    private enum ReleaseDateBenchmarkFeature implements Feature {
+        RELEASE_DATE_STRATEGY_ENABLED,
+        RELEASE_DATE_STRATEGY_DISABLED,
+        NO_STATE_CONFIGURED,
+        @EnabledByDefault
+        ENABLED_BY_DEFAULT,
+        DISABLED_BY_FEATURE_STATE;
+
+
+        public boolean isActive() {
+            return FeatureContext.getFeatureManager().isActive(this);
+        }
+    }
+
+    // create an in-memory state repository for our feature
+    @Setup(Level.Trial)
+    public void setupFeatureManager() {
+        FeatureManager featureManager = new FeatureManagerBuilder()
+                .featureEnums(ReleaseDateBenchmarkFeature.class)
+                .stateRepository(new InMemoryStateRepository())
+                .userProvider(new NoOpUserProvider())
+                .build();
+        // set up the toggle activation state
+        StaticFeatureManagerProvider.setFeatureManager(featureManager);
+        manager = featureManager;
+
+        FeatureState releaseDateFeatureState = new FeatureState(ReleaseDateBenchmarkFeature.RELEASE_DATE_STRATEGY_ENABLED);
+        releaseDateFeatureState.setEnabled(true);
+        releaseDateFeatureState.setStrategyId(ReleaseDateActivationStrategy.ID);
+        releaseDateFeatureState.setParameter(ReleaseDateActivationStrategy.PARAM_DATE, "2014-12-31");
+        releaseDateFeatureState.setParameter(ReleaseDateActivationStrategy.PARAM_TIME, "12:45:00");
+
+        FeatureState disabledReleaseDate = new FeatureState(ReleaseDateBenchmarkFeature.RELEASE_DATE_STRATEGY_DISABLED);
+        disabledReleaseDate.setEnabled(false);
+        disabledReleaseDate.setStrategyId(ReleaseDateActivationStrategy.ID);
+        disabledReleaseDate.setParameter(ReleaseDateActivationStrategy.PARAM_DATE, "2014-12-31");
+        disabledReleaseDate.setParameter(ReleaseDateActivationStrategy.PARAM_TIME, "12:45:00");
+
+        manager.setFeatureState(releaseDateFeatureState);
+        manager.setFeatureState(new FeatureState(ReleaseDateBenchmarkFeature.DISABLED_BY_FEATURE_STATE, false));
+        manager.setFeatureState(disabledReleaseDate);
+    }
+
+    @Benchmark
+    public int releaseDateStrategyEnabled() {
+        return (manager.isActive(ReleaseDateBenchmarkFeature.RELEASE_DATE_STRATEGY_ENABLED)) ? 0 : 1;
+    }
+
+    @Benchmark
+    public int releaseDateStrategyConfiguredButNotEnabled() {
+        return (manager.isActive(ReleaseDateBenchmarkFeature.RELEASE_DATE_STRATEGY_DISABLED)) ? 0 : 1;
+    }
+
+    @Benchmark
+    public int noFeatureStateSetBaseline() {
+        return (manager.isActive(ReleaseDateBenchmarkFeature.NO_STATE_CONFIGURED)) ? 0 : 1;
+    }
+
+    @Benchmark
+    public int disabledByAFeatureStateExplicitly() {
+        return (manager.isActive(ReleaseDateBenchmarkFeature.DISABLED_BY_FEATURE_STATE)) ? 0 : 1;
+    }
+
+    @Benchmark
+    public int enabledByDefaultByAnAnnotation() {
+        return (manager.isActive(ReleaseDateBenchmarkFeature.ENABLED_BY_DEFAULT)) ? 0 : 1;
+    }
+
+
+    // run this method to execute this test
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(FeatureStateBenchmarks.class.getSimpleName())
+                .threads(7)
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+}

--- a/togglz-benchmarks/src/main/java/org/togglz/benchmark/FeatureStateBenchmarks.java
+++ b/togglz-benchmarks/src/main/java/org/togglz/benchmark/FeatureStateBenchmarks.java
@@ -8,6 +8,7 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
@@ -27,12 +28,15 @@ import org.togglz.core.user.NoOpUserProvider;
 import java.util.concurrent.TimeUnit;
 
 /**
+ * Benchmark the performance of using an ActivationStrategy on the performance of a Togglz switch
+ *
  * @author Ryan Gardner
  * @date 5/12/16
  */
 @State(Scope.Benchmark)
 @BenchmarkMode({Mode.Throughput, Mode.SampleTime, Mode.SingleShotTime})
 @Measurement(iterations = 8, time = 1, timeUnit = TimeUnit.SECONDS)
+@Threads(7)
 @Warmup(iterations = 8, time = 1, timeUnit = TimeUnit.SECONDS)
 public class FeatureStateBenchmarks {
     FeatureManager manager;
@@ -112,8 +116,6 @@ public class FeatureStateBenchmarks {
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()
                 .include(FeatureStateBenchmarks.class.getSimpleName())
-                .threads(7)
-                .forks(1)
                 .build();
 
         new Runner(opt).run();

--- a/togglz-benchmarks/src/main/java/org/togglz/benchmark/ScriptEngineActivationStrategyBenchmark.java
+++ b/togglz-benchmarks/src/main/java/org/togglz/benchmark/ScriptEngineActivationStrategyBenchmark.java
@@ -8,6 +8,7 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
@@ -27,12 +28,16 @@ import org.togglz.core.user.NoOpUserProvider;
 import java.util.concurrent.TimeUnit;
 
 /**
+ * Benchmark the performance of the ScriptEngine-based activation strategy in
+ * terms of speed and memory footprint
+ *
  * @author Ryan Gardner
  * @date 5/13/16
  */
 @State(Scope.Benchmark)
 @BenchmarkMode({Mode.Throughput, Mode.SampleTime, Mode.SingleShotTime})
 @Measurement(iterations = 4, time = 10, timeUnit = TimeUnit.SECONDS)
+@Threads(7)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 public class ScriptEngineActivationStrategyBenchmark {
     FeatureManager manager;
@@ -99,8 +104,6 @@ public class ScriptEngineActivationStrategyBenchmark {
         Options opt = new OptionsBuilder()
                 .include(ScriptEngineActivationStrategyBenchmark.class.getSimpleName())
                 .addProfiler(GCProfiler.class)
-                .threads(7)
-                .forks(1)
                 .build();
 
         new Runner(opt).run();

--- a/togglz-benchmarks/src/main/java/org/togglz/benchmark/ScriptEngineActivationStrategyBenchmark.java
+++ b/togglz-benchmarks/src/main/java/org/togglz/benchmark/ScriptEngineActivationStrategyBenchmark.java
@@ -1,0 +1,111 @@
+package org.togglz.benchmark;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.togglz.core.Feature;
+import org.togglz.core.activation.ScriptEngineActivationStrategy;
+import org.togglz.core.context.FeatureContext;
+import org.togglz.core.context.StaticFeatureManagerProvider;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.manager.FeatureManagerBuilder;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.repository.mem.InMemoryStateRepository;
+import org.togglz.core.user.NoOpUserProvider;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Ryan Gardner
+ * @date 5/13/16
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode({Mode.Throughput, Mode.SampleTime, Mode.SingleShotTime})
+@Measurement(iterations = 4, time = 10, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
+public class ScriptEngineActivationStrategyBenchmark {
+    FeatureManager manager;
+
+    // a simple feature for this benchmark
+    private enum ScriptEngineActivationStrategyFeatures implements Feature {
+        ALWAYS_TRUE_SCRIPT_ENGINE_ACTIVATION_STRATEGY,
+        DISABLED_FEATURE,
+        DYNAMIC_SCRIPT_ENGINE_STRATEGY;
+
+
+        public boolean isActive() {
+            return FeatureContext.getFeatureManager().isActive(this);
+        }
+    }
+
+    // create an in-memory state repository for our feature
+    @Setup(Level.Trial)
+    public void setupFeatureManager() {
+        FeatureManager featureManager = new FeatureManagerBuilder()
+                .featureEnums(ScriptEngineActivationStrategyFeatures.class)
+                .stateRepository(new InMemoryStateRepository())
+                .userProvider(new NoOpUserProvider())
+                .build();
+        // set up the toggle activation state
+        StaticFeatureManagerProvider.setFeatureManager(featureManager);
+        manager = featureManager;
+
+        FeatureState alwaysTrueScriptEngineFeatureState = new FeatureState(ScriptEngineActivationStrategyFeatures.ALWAYS_TRUE_SCRIPT_ENGINE_ACTIVATION_STRATEGY);
+        alwaysTrueScriptEngineFeatureState.setEnabled(true);
+        alwaysTrueScriptEngineFeatureState.setStrategyId(ScriptEngineActivationStrategy.ID);
+        alwaysTrueScriptEngineFeatureState.setParameter(ScriptEngineActivationStrategy.PARAM_LANG, "nashorn");
+        alwaysTrueScriptEngineFeatureState.setParameter(ScriptEngineActivationStrategy.PARAM_SCRIPT, "true");
+
+        FeatureState dynamicScriptEngineState = new FeatureState(ScriptEngineActivationStrategyFeatures.DYNAMIC_SCRIPT_ENGINE_STRATEGY);
+        dynamicScriptEngineState.setEnabled(true);
+        dynamicScriptEngineState.setStrategyId(ScriptEngineActivationStrategy.ID);
+        dynamicScriptEngineState.setParameter(ScriptEngineActivationStrategy.PARAM_LANG, "nashorn");
+        dynamicScriptEngineState.setParameter(ScriptEngineActivationStrategy.PARAM_SCRIPT, "Math.random() < Math.pow(1 - (27 - date.getDate()) * 0.2, 3)");
+
+
+        manager.setFeatureState(alwaysTrueScriptEngineFeatureState);
+        manager.setFeatureState(dynamicScriptEngineState);
+    }
+
+    @Benchmark
+    public int scriptEngineThatAlwaysReturnsTrue() {
+        return (manager.isActive(ScriptEngineActivationStrategyFeatures.ALWAYS_TRUE_SCRIPT_ENGINE_ACTIVATION_STRATEGY)) ? 0 : 1;
+    }
+
+    @Benchmark
+    public int scriptEngineDoingDynamicThings() {
+        return (manager.isActive(ScriptEngineActivationStrategyFeatures.DYNAMIC_SCRIPT_ENGINE_STRATEGY)) ? 0 : 1;
+    }
+
+    @Benchmark
+    public int disabledFeatureWithNoScriptEngineInvolved() {
+        return (manager.isActive(ScriptEngineActivationStrategyFeatures.DISABLED_FEATURE)) ? 0 : 1;
+    }
+
+
+    // run this method to execute this test
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(ScriptEngineActivationStrategyBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .threads(7)
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+
+
+}

--- a/togglz-benchmarks/src/main/java/org/togglz/benchmark/TogglzOverheadBenchmark.java
+++ b/togglz-benchmarks/src/main/java/org/togglz/benchmark/TogglzOverheadBenchmark.java
@@ -1,0 +1,95 @@
+package org.togglz.benchmark;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.togglz.core.Feature;
+import org.togglz.core.context.FeatureContext;
+import org.togglz.core.context.StaticFeatureManagerProvider;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.manager.FeatureManagerBuilder;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.repository.mem.InMemoryStateRepository;
+import org.togglz.core.user.NoOpUserProvider;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Compare the overhead of togglz with an in-memory state repository vs a simple boolean flag
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode({Mode.Throughput, Mode.SampleTime, Mode.SingleShotTime})
+@Measurement(iterations = 6, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 6, time = 1, timeUnit = TimeUnit.SECONDS)
+public class TogglzOverheadBenchmark {
+    FeatureManager manager;
+    boolean enabled = false;
+
+    // a simple feature for this benchmark
+    private enum OverheadFeature implements Feature {
+        FEATURE;
+
+        public boolean isActive() {
+            return FeatureContext.getFeatureManager().isActive(this);
+        }
+    }
+
+    // create an in-memory state repository for our feature
+    @Setup(Level.Trial)
+    public void setupFeatureManager() {
+        FeatureManager featureManager = new FeatureManagerBuilder()
+                .featureEnums(OverheadFeature.class)
+                .stateRepository(new InMemoryStateRepository())
+                .userProvider(new NoOpUserProvider())
+                .build();
+        manager = featureManager;
+        // set the StaticFeatureManagerProvider to use this feature manager
+        StaticFeatureManagerProvider.setFeatureManager(featureManager);
+    }
+
+    // toggle the state between iterations to keep the compiler honest
+    @Setup(Level.Iteration)
+    public void toggleEnabledState() {
+        enabled = !enabled;
+        manager.setFeatureState(new FeatureState(OverheadFeature.FEATURE, enabled));
+    }
+
+    @Benchmark
+    public int aSimpleBooleanIfStatement() {
+        return (enabled) ? 1 : 0;
+    }
+
+    @Benchmark
+    public int featureManagerStateLookup() {
+        return (manager.isActive(OverheadFeature.FEATURE)) ? 1 : 0;
+    }
+
+    @Benchmark
+    public int isActiveMethodOnEnum() {
+        return (OverheadFeature.FEATURE.isActive()) ? 1 : 0;
+    }
+
+    // run this method to execute this test
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(TogglzOverheadBenchmark.class.getSimpleName())
+                .warmupIterations(5)
+                .measurementIterations(4)
+                .threads(8)
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+}

--- a/togglz-benchmarks/src/main/java/org/togglz/benchmark/TogglzOverheadBenchmark.java
+++ b/togglz-benchmarks/src/main/java/org/togglz/benchmark/TogglzOverheadBenchmark.java
@@ -8,6 +8,7 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
@@ -30,7 +31,8 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 @BenchmarkMode({Mode.Throughput, Mode.SampleTime, Mode.SingleShotTime})
 @Measurement(iterations = 6, time = 1, timeUnit = TimeUnit.SECONDS)
-@Warmup(iterations = 6, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Threads(7)
 public class TogglzOverheadBenchmark {
     FeatureManager manager;
     boolean enabled = false;
@@ -83,9 +85,6 @@ public class TogglzOverheadBenchmark {
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()
                 .include(TogglzOverheadBenchmark.class.getSimpleName())
-                .warmupIterations(5)
-                .measurementIterations(4)
-                .threads(8)
                 .forks(1)
                 .build();
 


### PR DESCRIPTION
There is a README.md file that describes how to execute these benchmarks. 

I don't have then running automatically as part of the build because they take some time to run - a few minutes each one.

You can either package them up and run them all at once or you can run them individually in an IDE. Running them individually in an IDE is pretty cool because in your IDE (at least in IntelliJ) you can open the togglz project, make changes to something, and then run just the one benchmark you are interested in to see if your new tweaks made things any better or not. 

I added a baseline one that compares the performance of the togglz vs a boolean if flag, another one that looks at how it performs when you use an activation strategy, and another one that tests how it performs when you use a ScriptEngine.
