### PR TITLE
Device Activation Strategy based on spring mobile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,7 @@
     <module>zookeeper</module>
     <module>dynamodb</module>
     <module>benchmarks</module>
+    <module>spring-mobile</module>
   </modules>
 
   <developers>

--- a/spring-mobile/pom.xml
+++ b/spring-mobile/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.togglz</groupId>
+    <artifactId>togglz-project</artifactId>
+    <version>2.4.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>togglz-spring-mobile</artifactId>
+  <name>Togglz - Spring mobile integration</name>
+  <description>Togglz - Spring mobile integration</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.togglz</groupId>
+      <artifactId>togglz-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.mobile</groupId>
+      <artifactId>spring-mobile-device</artifactId>
+      <version>1.1.4.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+      <version>1.0.1.Final</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.togglz</groupId>
+      <artifactId>togglz-test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/spring-mobile/src/main/java/org/togglz/spring/mobile/DeviceActivationStrategy.java
+++ b/spring-mobile/src/main/java/org/togglz/spring/mobile/DeviceActivationStrategy.java
@@ -1,0 +1,71 @@
+package org.togglz.spring.mobile;
+
+import org.springframework.mobile.device.Device;
+import org.springframework.mobile.device.DeviceType;
+import org.springframework.mobile.device.DeviceUtils;
+import org.togglz.core.activation.Parameter;
+import org.togglz.core.activation.ParameterBuilder;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.spi.ActivationStrategy;
+import org.togglz.core.user.FeatureUser;
+import org.togglz.servlet.util.HttpServletRequestHolder;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.springframework.mobile.device.DeviceType.MOBILE;
+import static org.springframework.mobile.device.DeviceType.NORMAL;
+import static org.springframework.mobile.device.DeviceType.TABLET;
+
+
+/**
+ * Activation strategy that will use the Device type used by client to decide if a feature is active or not.
+ * Based on spring-mobile http://projects.spring.io/spring-mobile/
+ *
+ * Created by achhabra on 10/17/16.
+ * @author Anupriya Chhabra
+ *
+ */
+public class DeviceActivationStrategy implements ActivationStrategy {
+
+    public static final String YES = "YES";
+    public static final String ID = "devicerollout";
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public String getName() {
+        return "Device Rollout";
+    }
+
+    @Override
+    public Parameter[] getParameters() {
+        return new Parameter[]{
+                ParameterBuilder.create(NORMAL.name())
+                        .label("Turn this feature ON for desktop").matching("(?i)(YES|NO)")
+                        .description("Feature will be off by default enter 'YES' in box above to enable"),
+                ParameterBuilder.create(TABLET.name())
+                        .label("Turn this feature ON for Tablet").matching("(?i)(YES|NO)")
+                        .description("Feature will be off by default enter 'YES' in box above to enable"),
+                ParameterBuilder.create(MOBILE.name())
+                        .label("Turn this feature ON for Mobile").matching("(?i)(YES|NO)")
+                        .description("Feature will be off by default enter 'YES' in box above to enable")
+        };
+    }
+
+    @Override
+    public boolean isActive(FeatureState featureState, FeatureUser user) {
+
+        HttpServletRequest request = HttpServletRequestHolder.get();
+        if (request != null) {
+            Device device = DeviceUtils.getCurrentDevice(request);
+            DeviceType deviceType = device.isMobile() ? MOBILE : (device.isTablet() ? TABLET : NORMAL);
+            return (YES.equalsIgnoreCase(featureState.getParameter(deviceType.name())));
+
+        }
+        return false;
+
+    }
+}

--- a/spring-mobile/src/main/resources/META-INF.services/org.togglz.core.spi.ActivationStrategy
+++ b/spring-mobile/src/main/resources/META-INF.services/org.togglz.core.spi.ActivationStrategy
@@ -1,0 +1,1 @@
+org.togglz.spring.mobile.DeviceActivationStrategy

--- a/spring-mobile/src/test/java/org/togglz/spring/mobile/DeviceActivationStrategyTest.java
+++ b/spring-mobile/src/test/java/org/togglz/spring/mobile/DeviceActivationStrategyTest.java
@@ -1,0 +1,150 @@
+package org.togglz.spring.mobile;
+
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.mobile.device.Device;
+import org.springframework.mobile.device.DeviceType;
+import org.togglz.core.Feature;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.servlet.util.HttpServletRequestHolder;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.togglz.spring.mobile.DeviceActivationStrategyTest.MockRequest.requestFrom;
+import static org.togglz.spring.mobile.DeviceActivationStrategyTest.MockRequestAssert.assertThat;
+import static org.springframework.mobile.device.DeviceType.MOBILE;
+import static org.springframework.mobile.device.DeviceType.NORMAL;
+import static org.springframework.mobile.device.DeviceType.TABLET;
+
+
+
+/**
+ * Created by achhabra on 10/17/16.
+ */
+public class DeviceActivationStrategyTest {
+
+    protected static class MockRequest {
+        private final HttpServletRequest request;
+
+        public static MockRequest requestFrom(DeviceType deviceType) {
+            Device device = mock(Device.class);
+            when(device.isNormal()).thenReturn(NORMAL.equals(deviceType));
+            when(device.isTablet()).thenReturn(TABLET.equals(deviceType));
+            when(device.isMobile()).thenReturn(MOBILE.equals(deviceType));
+            return new MockRequest(device);
+        }
+
+        private MockRequest(Device device) {
+            request = mock(HttpServletRequest.class);
+            when(request.getAttribute("currentDevice")).thenReturn(device);
+            HttpServletRequestHolder.bind(request);
+        }
+        
+    }
+
+    protected static class MockRequestAssert extends org.assertj.core.api.AbstractAssert<MockRequestAssert, MockRequest> {
+        protected MockRequestAssert(MockRequest actual) {
+            super(actual, MockRequestAssert.class);
+        }
+
+        public static MockRequestAssert assertThat(MockRequest actual) {
+            return new MockRequestAssert(actual);
+        }
+
+        public MockRequestAssert isActiveWithParams(String... params) {
+            if (!strategy().isActive(featureState(params), null)) {
+                Assertions.fail("Expected the strategy to turn the feature active with params " + params);
+            }
+            return this;
+        }
+
+        public MockRequestAssert isInactiveWithParams(String... params) {
+            if (strategy().isActive(featureState(params), null)) {
+                Assertions.fail("Expected the strategy to turn the feature inactive with params " + params);
+            }
+            return this;
+        }
+
+        private static DeviceActivationStrategy strategy() {
+            return new DeviceActivationStrategy();
+        }
+
+
+        private static FeatureState featureState(String... ips) {
+            return new FeatureState(TestFeature.TEST_FEATURE)
+                    .enable()
+                    .setStrategyId(DeviceActivationStrategy.ID)
+                    .setParameter(NORMAL.name(), ips[0])
+                    .setParameter(TABLET.name(), ips[1])
+                    .setParameter(MOBILE.name(), ips[2]);
+        }
+
+        private enum TestFeature implements Feature {
+            TEST_FEATURE
+        }
+    }
+
+    public void cleanup() {
+        HttpServletRequestHolder.release();
+    }
+
+    @Test
+    public void shouldBeInactiveForEmptyParams() throws Exception {
+        String[] emptyArguments = new String[]{"", "", ""};
+        assertThat(requestFrom(NORMAL)).isInactiveWithParams(emptyArguments);
+        cleanup();
+        assertThat(requestFrom(TABLET)).isInactiveWithParams(emptyArguments);
+        cleanup();
+        assertThat(requestFrom(MOBILE)).isInactiveWithParams(emptyArguments);
+        cleanup();
+    }
+
+    @Test
+    public void shouldBeActiveForDesktop() throws Exception {
+        String[] desktopOn = new String[]{"YES", "NO", "NO"};
+        assertThat(requestFrom(NORMAL)).isActiveWithParams(desktopOn);
+        cleanup();
+        assertThat(requestFrom(TABLET)).isInactiveWithParams(desktopOn);
+        cleanup();
+        assertThat(requestFrom(MOBILE)).isInactiveWithParams(desktopOn);
+        cleanup();
+    }
+
+    @Test
+    public void shouldBeActiveForTablet() throws Exception {
+        String[] tabletOn = new String[]{"NO", "YES", "NO"};
+        assertThat(requestFrom(NORMAL)).isInactiveWithParams(tabletOn);
+        cleanup();
+        assertThat(requestFrom(TABLET)).isActiveWithParams(tabletOn);
+        cleanup();
+        assertThat(requestFrom(MOBILE)).isInactiveWithParams(tabletOn);
+        cleanup();
+    }
+
+    @Test
+    public void shouldBeActiveForMobile() throws Exception {
+        String[] mobileOn = new String[]{"NO", "NO", "YES"};
+        assertThat(requestFrom(NORMAL)).isInactiveWithParams(mobileOn);
+        cleanup();
+        assertThat(requestFrom(TABLET)).isInactiveWithParams(mobileOn);
+        cleanup();
+        assertThat(requestFrom(MOBILE)).isActiveWithParams(mobileOn);
+        cleanup();
+    }
+
+    @Test
+    public void shouldBeAccurateForLowerCaseParams() throws Exception {
+        String[] desktopOn = new String[]{"yes", "no", "yes"};
+        assertThat(requestFrom(NORMAL)).isActiveWithParams(desktopOn);
+        cleanup();
+        String[] tabletOn = new String[]{"no", "yes", "NO"};
+        assertThat(requestFrom(TABLET)).isActiveWithParams(tabletOn);
+        cleanup();
+        String[] mobileOn = new String[]{"no", "no", "yes"};
+        assertThat(requestFrom(MOBILE)).isActiveWithParams(mobileOn);
+        cleanup();
+    }
+}

--- a/spring-mobile/template.mf
+++ b/spring-mobile/template.mf
@@ -1,0 +1,12 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: org.togglz.spring.mobile
+Bundle-Vendor: http://www.togglz.org/
+Bundle-Version: ${project.version}
+Bundle-Name: ${project.name}
+Version-Patterns:
+ default;pattern="[=.=.=, =.+1.0)"
+Import-Template:
+ javax.servlet.*;version="0",
+ org.togglz.*;version="${osgi.bundles.version:default}",
+ org.springframework.mobile.*;version="1.1.4.RELEASE"


### PR DESCRIPTION
A new activation strategy to turn on/off a feature based on the device type of user. This is based on spring-mobile project http://projects.spring.io/spring-mobile/. I am currently using this in my work and this looked like a nice thing to give back to the Togglz community.