### PR TITLE
Spring environment properties activation strategy

### DIFF
--- a/spring-core/pom.xml
+++ b/spring-core/pom.xml
@@ -47,16 +47,5 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 </project>

--- a/spring-core/pom.xml
+++ b/spring-core/pom.xml
@@ -13,7 +13,7 @@
   <description>Togglz - Spring Framework integration</description>
 
   <properties>
-    <spring.version>3.0.7.RELEASE</spring.version>
+    <spring.version>3.1.4.RELEASE</spring.version>
   </properties>
 
   <dependencies>
@@ -28,6 +28,23 @@
       <artifactId>spring-context</artifactId>
       <version>${spring.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>${spring.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/spring-core/src/main/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategy.java
+++ b/spring-core/src/main/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategy.java
@@ -51,7 +51,8 @@ public class SpringEnvironmentPropertyActivationStrategy implements ActivationSt
     public boolean isActive(FeatureState featureState, FeatureUser user) {
         ApplicationContext applicationContext = ContextClassLoaderApplicationContextHolder.get();
         if (applicationContext == null) {
-            return false;
+            throw new IllegalStateException("ApplicationContext could not be found, which can occur if there is no bean for "
+                + "TogglzApplicationContextBinderApplicationListener when TogglzAutoConfiguration is not being used");
         }
 
         Environment environment = applicationContext.getEnvironment();

--- a/spring-core/src/main/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategy.java
+++ b/spring-core/src/main/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategy.java
@@ -25,7 +25,6 @@ import org.togglz.spring.util.ContextClassLoaderApplicationContextHolder;
 public class SpringEnvironmentPropertyActivationStrategy implements ActivationStrategy {
 
     public static final String ID = "spring-environment-property";
-    static final String NAME = "Spring Environment Property";
     public static final String PARAM_NAME = "name";
 
     private static String getPropertyName(FeatureState featureState) {
@@ -45,7 +44,7 @@ public class SpringEnvironmentPropertyActivationStrategy implements ActivationSt
 
     @Override
     public String getName() {
-        return NAME;
+        return "Spring Environment Property";
     }
 
     @Override

--- a/spring-core/src/main/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategy.java
+++ b/spring-core/src/main/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategy.java
@@ -1,0 +1,71 @@
+package org.togglz.spring.activation;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.togglz.core.Feature;
+import org.togglz.core.activation.Parameter;
+import org.togglz.core.activation.ParameterBuilder;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.spi.ActivationStrategy;
+import org.togglz.core.user.FeatureUser;
+import org.togglz.core.util.Strings;
+import org.togglz.spring.util.ContextClassLoaderApplicationContextHolder;
+
+/**
+ * <p>
+ * An activation strategy based on the values of properties accessible within the Spring environment.
+ * </p>
+ * <p>
+ * It can either be based on a given property name, passed as a parameter, or a property name constructed from the
+ * {@link Feature} itself (e.g. {@code com.example.MyFeatures.FEATURE_NAME}).
+ * </p>
+ *
+ * @author Alasdair Mercer
+ */
+public class SpringEnvironmentPropertyActivationStrategy implements ActivationStrategy {
+
+    public static final String ID = "spring-environment-property";
+    static final String NAME = "Spring Environment Property";
+    public static final String PARAM_NAME = "name";
+
+    private static String getPropertyName(FeatureState featureState) {
+        String propertyName = featureState.getParameter(PARAM_NAME);
+        if (Strings.isNotBlank(propertyName)) {
+            return propertyName;
+        }
+
+        Feature feature = featureState.getFeature();
+        return feature.getClass().getName() + "." + feature.name();
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean isActive(FeatureState featureState, FeatureUser user) {
+        ApplicationContext applicationContext = ContextClassLoaderApplicationContextHolder.get();
+        if (applicationContext == null) {
+            return false;
+        }
+
+        Environment environment = applicationContext.getEnvironment();
+        return environment.getProperty(getPropertyName(featureState), Boolean.TYPE, false);
+    }
+
+    @Override
+    public Parameter[] getParameters() {
+        return new Parameter[] {
+            ParameterBuilder.create(PARAM_NAME)
+                .optional()
+                .label("Property Name")
+                .description("The name of the environment property to be used to determine whether the feature is enabled.")
+        };
+    }
+}

--- a/spring-core/src/main/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategy.java
+++ b/spring-core/src/main/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategy.java
@@ -16,8 +16,8 @@ import org.togglz.spring.util.ContextClassLoaderApplicationContextHolder;
  * An activation strategy based on the values of properties accessible within the Spring environment.
  * </p>
  * <p>
- * It can either be based on a given property name, passed as a parameter, or a property name constructed from the
- * {@link Feature} itself (e.g. {@code com.example.MyFeatures.FEATURE_NAME}).
+ * It can either be based on a given property name, passed as a parameter, or a property name derived from the
+ * {@link Feature} itself (e.g. {@code "togglz.FEATURE_NAME"}).
  * </p>
  *
  * @author Alasdair Mercer
@@ -33,8 +33,7 @@ public class SpringEnvironmentPropertyActivationStrategy implements ActivationSt
             return propertyName;
         }
 
-        Feature feature = featureState.getFeature();
-        return feature.getClass().getName() + "." + feature.name();
+        return "togglz." + featureState.getFeature().name();
     }
 
     @Override
@@ -51,8 +50,9 @@ public class SpringEnvironmentPropertyActivationStrategy implements ActivationSt
     public boolean isActive(FeatureState featureState, FeatureUser user) {
         ApplicationContext applicationContext = ContextClassLoaderApplicationContextHolder.get();
         if (applicationContext == null) {
-            throw new IllegalStateException("ApplicationContext could not be found, which can occur if there is no bean for "
-                + "TogglzApplicationContextBinderApplicationListener when TogglzAutoConfiguration is not being used");
+            throw new IllegalStateException("ApplicationContext could not be found, which can occur if there is no "
+                + "bean for TogglzApplicationContextBinderApplicationListener when TogglzAutoConfiguration is not "
+                + "being used");
         }
 
         Environment environment = applicationContext.getEnvironment();
@@ -65,7 +65,8 @@ public class SpringEnvironmentPropertyActivationStrategy implements ActivationSt
             ParameterBuilder.create(PARAM_NAME)
                 .optional()
                 .label("Property Name")
-                .description("The name of the environment property to be used to determine whether the feature is enabled.")
+                .description("The name of the environment property to be used to determine whether the feature is "
+                    + "enabled.")
         };
     }
 }

--- a/spring-core/src/main/resources/META-INF/services/org.togglz.core.spi.ActivationStrategy
+++ b/spring-core/src/main/resources/META-INF/services/org.togglz.core.spi.ActivationStrategy
@@ -1,0 +1,1 @@
+org.togglz.spring.activation.SpringEnvironmentPropertyActivationStrategy

--- a/spring-core/src/test/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategyTest.java
+++ b/spring-core/src/test/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategyTest.java
@@ -90,11 +90,11 @@ public class SpringEnvironmentPropertyActivationStrategyTest {
         assertEquals(enabled, strategy.isActive(featureState, null));
     }
 
-    @Test
-    public void testIsActiveWithNoApplicationContext() {
+    @Test(expected = IllegalStateException.class)
+    public void testIsActiveThrowsWhenNoApplicationContext() {
         FeatureState featureState = new FeatureState(TestFeatures.FEATURE_ONE, true);
 
-        assertFalse(strategy.isActive(featureState, null));
+        strategy.isActive(featureState, null);
     }
 
     @Test

--- a/spring-core/src/test/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategyTest.java
+++ b/spring-core/src/test/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategyTest.java
@@ -70,9 +70,7 @@ public class SpringEnvironmentPropertyActivationStrategyTest {
 
         ContextClassLoaderApplicationContextHolder.bind(mockApplicationContext);
 
-        when(mockEnvironment.getProperty(
-            "org.togglz.spring.activation.SpringEnvironmentPropertyActivationStrategyTest$TestFeatures.FEATURE_ONE",
-            Boolean.TYPE, false)).thenReturn(enabled);
+        when(mockEnvironment.getProperty("togglz.FEATURE_ONE", Boolean.TYPE, false)).thenReturn(enabled);
 
         assertEquals(enabled, strategy.isActive(featureState, null));
     }

--- a/spring-core/src/test/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategyTest.java
+++ b/spring-core/src/test/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategyTest.java
@@ -1,0 +1,119 @@
+package org.togglz.spring.activation;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.togglz.core.Feature;
+import org.togglz.core.activation.Parameter;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.util.Strings;
+import org.togglz.spring.util.ContextClassLoaderApplicationContextHolder;
+
+/**
+ * <p>
+ * Tests for the {@link SpringEnvironmentPropertyActivationStrategy} class.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ */
+@RunWith(Theories.class)
+public class SpringEnvironmentPropertyActivationStrategyTest {
+
+    @DataPoints
+    public static final boolean[] DATA_POINTS = { true, false };
+
+    @Mock
+    private ApplicationContext mockApplicationContext;
+    @Mock
+    private Environment mockEnvironment;
+
+    private SpringEnvironmentPropertyActivationStrategy strategy;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        when(mockApplicationContext.getEnvironment()).thenReturn(mockEnvironment);
+
+        strategy = new SpringEnvironmentPropertyActivationStrategy();
+    }
+
+    @After
+    public void tearDown() {
+        ContextClassLoaderApplicationContextHolder.release();
+    }
+
+    @Test
+    public void testGetId() {
+        assertEquals(SpringEnvironmentPropertyActivationStrategy.ID, strategy.getId());
+    }
+
+    @Test
+    public void testGetName() {
+        assertEquals(SpringEnvironmentPropertyActivationStrategy.NAME, strategy.getName());
+    }
+
+    @Theory
+    public void testIsActiveWithNoParam(boolean enabled) {
+        FeatureState featureState = new FeatureState(TestFeatures.FEATURE_ONE, !enabled);
+
+        ContextClassLoaderApplicationContextHolder.bind(mockApplicationContext);
+
+        when(mockEnvironment.getProperty(
+            "org.togglz.spring.activation.SpringEnvironmentPropertyActivationStrategyTest$TestFeatures.FEATURE_ONE",
+            Boolean.TYPE, false)).thenReturn(enabled);
+
+        assertEquals(enabled, strategy.isActive(featureState, null));
+    }
+
+    @Theory
+    public void testIsActiveWithParam(boolean enabled) {
+        String paramValue = "foo";
+        FeatureState featureState = new FeatureState(TestFeatures.FEATURE_ONE, !enabled);
+        featureState.setParameter(SpringEnvironmentPropertyActivationStrategy.PARAM_NAME, paramValue);
+
+        ContextClassLoaderApplicationContextHolder.bind(mockApplicationContext);
+
+        when(mockEnvironment.getProperty(paramValue, Boolean.TYPE, false)).thenReturn(enabled);
+
+        assertEquals(enabled, strategy.isActive(featureState, null));
+    }
+
+    @Test
+    public void testIsActiveWithNoApplicationContext() {
+        FeatureState featureState = new FeatureState(TestFeatures.FEATURE_ONE, true);
+
+        assertFalse(strategy.isActive(featureState, null));
+    }
+
+    @Test
+    public void testGetParameters() {
+        Parameter[] parameters = strategy.getParameters();
+
+        assertEquals(1, parameters.length);
+
+        Parameter parameter = parameters[0];
+
+        assertNotNull(parameter);
+        assertEquals(SpringEnvironmentPropertyActivationStrategy.PARAM_NAME, parameter.getName());
+        assertTrue(parameter.isOptional());
+        assertTrue(Strings.isNotBlank(parameter.getLabel()));
+        assertTrue(Strings.isNotBlank(parameter.getDescription()));
+    }
+
+    public enum TestFeatures implements Feature {
+
+        FEATURE_ONE
+    }
+}

--- a/spring-core/src/test/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategyTest.java
+++ b/spring-core/src/test/java/org/togglz/spring/activation/SpringEnvironmentPropertyActivationStrategyTest.java
@@ -61,7 +61,7 @@ public class SpringEnvironmentPropertyActivationStrategyTest {
 
     @Test
     public void testGetName() {
-        assertEquals(SpringEnvironmentPropertyActivationStrategy.NAME, strategy.getName());
+        assertTrue(Strings.isNotBlank(strategy.getName()));
     }
 
     @Theory


### PR DESCRIPTION
This adds a new activation strategy designed to support Environment properties to integrate feature toggle properties into the same property sources as the rest of the application properties.

It supports a parameter to specify the property but will gracefully fallback to a property name generated from the `Feature` instance and its class (e.g. `com.example.MyFeatures.FEATURE_NAME`).

Related Spring Docs: http://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html#beans-property-source-abstraction