### PR TITLE
Moved TogglzApplicationContextBinderApplicationListener to togglz-spring-core

### DIFF
--- a/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzAutoConfiguration.java
+++ b/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzAutoConfiguration.java
@@ -41,7 +41,6 @@ import org.togglz.core.manager.EmptyFeatureProvider;
 import org.togglz.core.manager.EnumBasedFeatureProvider;
 import org.togglz.core.manager.FeatureManager;
 import org.togglz.core.manager.FeatureManagerBuilder;
-import org.togglz.core.metadata.FeatureMetaData;
 import org.togglz.core.repository.StateRepository;
 import org.togglz.core.repository.cache.CachingStateRepository;
 import org.togglz.core.repository.composite.CompositeStateRepository;
@@ -53,14 +52,13 @@ import org.togglz.core.spi.ActivationStrategy;
 import org.togglz.core.spi.FeatureProvider;
 import org.togglz.core.user.NoOpUserProvider;
 import org.togglz.core.user.UserProvider;
+import org.togglz.spring.listener.TogglzApplicationContextBinderApplicationListener;
 import org.togglz.spring.security.SpringSecurityUserProvider;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Togglz.

--- a/spring-core/pom.xml
+++ b/spring-core/pom.xml
@@ -30,5 +30,16 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/spring-core/src/main/java/org/togglz/spring/listener/TogglzApplicationContextBinderApplicationListener.java
+++ b/spring-core/src/main/java/org/togglz/spring/listener/TogglzApplicationContextBinderApplicationListener.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.togglz.spring.boot.autoconfigure;
+package org.togglz.spring.listener;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;

--- a/spring-core/src/test/java/org/togglz/spring/listener/TogglzApplicationContextBinderApplicationListenerTest.java
+++ b/spring-core/src/test/java/org/togglz/spring/listener/TogglzApplicationContextBinderApplicationListenerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.togglz.spring.boot.autoconfigure;
+package org.togglz.spring.listener;
 
 import org.junit.After;
 import org.junit.Before;


### PR DESCRIPTION
The Spring `BeanFinder` implementations rely on `ContextClassLoaderApplicationContextHolder` to provide the required `ApplicationContext`. However, currently, the only time that `ContextClassLoaderApplicationContextHolder#bind` is called with the `ApplicationContext` instance is from within `TogglzApplicationContextBinderApplicationListener` which resides within togglz-spring-boot-starter.

This isn't a huge issue as applications can simply depend on that module and have access to it. However, it feels strange that I'm having to depend on a module targeting Spring Boot to make something work that's in togglz-spring-core. This PR simply moves the `TogglzApplicationContextBinderApplicationListener` class from togglz-spring-boot-starter into togglz-spring-core. This means that applications not really caring about the Spring Boot automatic configuration etc can still register this bean in order to make full use of togglz-spring-core using something like the following:

Java-based Spring configurations:
``` java
@Bean
public TogglzApplicationContextBinderApplicationListener togglzApplicationContextBinderApplicationListener() {
    return new TogglzApplicationContextBinderApplicationListener();
}
```

XML-based Spring configurations:
``` xml
<bean name="togglzApplicationContextBinderApplicationListener" class="org.togglz.spring.listener.TogglzApplicationContextBinderApplicationListener" />
```

I must state that this would obviously be a breaking change for anyone already doing something like the above as the package will have changed and they may need to add the togglz-spring-core dependency. This would be something best captured on the [Updating Notes](https://www.togglz.org/updating-notes.html) page.

Currently, the `ContextClassLoaderApplicationContextHolder` is only really being used by the Spring `BeanFinder` implementations. However, both of the Spring-related `ActivationStrategy` implementations that I've submitted (#186 & #188) rely on it too in order to get the Spring `Environment` instance that they require. If this listener is not registered as a bean, either explicitly or via the Spring Boot auto-configuration, those activation strategies will never activate features as they'll fail to lookup the `ApplicationContext`.