### PR TITLE
release date activation strategy: show current date in format examples

### DIFF
--- a/core/src/main/java/org/togglz/core/activation/ReleaseDateActivationStrategy.java
+++ b/core/src/main/java/org/togglz/core/activation/ReleaseDateActivationStrategy.java
@@ -1,11 +1,9 @@
 package org.togglz.core.activation;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.text.*;
 import java.util.Date;
 
-import org.togglz.core.logging.Log;
-import org.togglz.core.logging.LogFactory;
+import org.togglz.core.logging.*;
 import org.togglz.core.repository.FeatureState;
 import org.togglz.core.spi.ActivationStrategy;
 import org.togglz.core.user.FeatureUser;
@@ -14,10 +12,10 @@ import org.togglz.core.util.Strings;
 public class ReleaseDateActivationStrategy implements ActivationStrategy {
 
     private final Log log = LogFactory.getLog(ReleaseDateActivationStrategy.class);
+    private static final String PARAM_DATE = "date";
+    private static final String PARAM_TIME = "time";
 
     public static final String ID = "release-date";
-    public static final String PARAM_DATE = "date";
-    public static final String PARAM_TIME = "time";
 
     @Override
     public String getId() {
@@ -31,7 +29,6 @@ public class ReleaseDateActivationStrategy implements ActivationStrategy {
 
     @Override
     public boolean isActive(FeatureState featureState, FeatureUser user) {
-
         String dateStr = featureState.getParameter(PARAM_DATE);
         String timeStr = featureState.getParameter(PARAM_TIME);
 
@@ -40,11 +37,9 @@ public class ReleaseDateActivationStrategy implements ActivationStrategy {
             return new Date().after(releaseDate);
         }
         return false;
-
     }
 
     private Date parseReleaseDate(String dateStr, String timeStr) {
-
         StringBuilder fullDate = new StringBuilder();
         fullDate.append(dateStr.trim());
         fullDate.append('T');
@@ -68,10 +63,23 @@ public class ReleaseDateActivationStrategy implements ActivationStrategy {
     public Parameter[] getParameters() {
         return new Parameter[] {
                 ParameterBuilder.create(PARAM_DATE).label("Date").matching("\\d{4}\\-\\d{2}\\-\\d{2}")
-                    .description("Release date of the feature. Format: 2012-12-31"),
+                        .description("Release date of the feature. Format: " + getCurrentDate()),
                 ParameterBuilder.create(PARAM_TIME).label("Time").matching("\\d{2}\\:\\d{2}\\:\\d{2}").optional()
-                    .description("Optional time for the release day. The default value is midnight. Format: 14:45:00")
-        };
+                        .description("Optional time for the release day. The default value is midnight. Format: "
+                                + getCurrentTime()) };
+    }
+
+    private String getCurrentDate() {
+        return getCurrent("yyyy-MM-dd");
+    }
+
+    private String getCurrent(String pattern) {
+        Date current = new Date();
+        return new SimpleDateFormat(pattern).format(current);
+    }
+
+    private String getCurrentTime() {
+        return getCurrent("HH:mm:ss");
     }
 
 }


### PR DESCRIPTION
Maybe showing the current date and time in the examples for the release date activation strategy simplifies the configuration for some users. At least I am always unsure wether it's UTC or local time.