### PR TITLE
Console: One-click feature enable/disable

### DIFF
--- a/console/src/main/java/org/togglz/console/handlers/index/IndexPageHandler.java
+++ b/console/src/main/java/org/togglz/console/handlers/index/IndexPageHandler.java
@@ -1,6 +1,7 @@
 package org.togglz.console.handlers.index;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -12,6 +13,9 @@ import org.togglz.core.manager.FeatureManager;
 import org.togglz.core.metadata.FeatureMetaData;
 import org.togglz.core.repository.FeatureState;
 import org.togglz.core.spi.ActivationStrategy;
+import org.togglz.core.util.Services;
+import org.togglz.servlet.spi.CSRFToken;
+import org.togglz.servlet.spi.CSRFTokenProvider;
 
 import com.floreysoft.jmte.Engine;
 
@@ -42,7 +46,16 @@ public class IndexPageHandler extends RequestHandlerBase {
             tabView.add(feature, metadata, featureState);
         }
 
+        List<CSRFToken> tokens = new ArrayList<CSRFToken>();
+        for (CSRFTokenProvider provider : Services.get(CSRFTokenProvider.class)) {
+            CSRFToken token = provider.getToken(event.getRequest());
+            if (token != null) {
+                tokens.add(token);
+            }
+        }
+
         Map<String, Object> model = new HashMap<String, Object>();
+        model.put("tokens", tokens);
         model.put("tabView", tabView);
 
         String template = getResourceAsString("index.html");

--- a/console/src/main/resources/org/togglz/console/edit.html
+++ b/console/src/main/resources/org/togglz/console/edit.html
@@ -1,7 +1,7 @@
 <form action="edit" method="POST" class="form-horizontal">
 
   ${if !model.valid}
-    <div class="alert alert-error">
+    <div class="alert alert-danger">
       <button type="button" class="close" data-dismiss="alert">×</button>
       ${foreach model.validationErrors error}
         <div>${error}</div>

--- a/console/src/main/resources/org/togglz/console/index.html
+++ b/console/src/main/resources/org/togglz/console/index.html
@@ -45,8 +45,11 @@
                 ${end}
               </td>
               <td class="feature-status">
-                <span class="glyphicon glyphicon-lg glyphicon-${if feature.enabled}ok-sign feature-enabled${else}remove-sign feature-disabled${end}"
-                      title="Current state of ${feature.label}: ${if feature.enabled}enabled${else}disabled${end}"></span>
+              	<form method="POST" action="edit">
+              		<input type="hidden" name="f" value="${feature.name}">
+              		<input type="hidden" name="enabled" value="${if feature.enabled}${else}enabled${end}">
+              		<input type="submit" class="btn btn-${if feature.enabled}success${else}danger${end}" value="${if feature.enabled}Enabled${else}Disabled${end}">
+              	</form>
               </td>
               <td class="feature-strategy">
                 ${feature.strategy.label}

--- a/console/src/main/resources/org/togglz/console/index.html
+++ b/console/src/main/resources/org/togglz/console/index.html
@@ -46,9 +46,12 @@
               </td>
               <td class="feature-status">
               	<form method="POST" action="edit">
-              		<input type="hidden" name="f" value="${feature.name}">
-              		<input type="hidden" name="enabled" value="${if feature.enabled}${else}enabled${end}">
-              		<input type="submit" class="btn btn-${if feature.enabled}success${else}danger${end}" value="${if feature.enabled}Enabled${else}Disabled${end}">
+                    ${foreach tokens token}
+                    <input type="hidden" name="${token.name}" value="${token.value}"/>
+                    ${end}
+                    <input type="hidden" name="f" value="${feature.name}">
+                    <input type="hidden" name="enabled" value="${if feature.enabled}${else}enabled${end}">
+                    <input type="submit" class="btn btn-sm btn-${if feature.enabled}success${else}danger${end}" value="${if feature.enabled}Enabled${else}Disabled${end}">
               	</form>
               </td>
               <td class="feature-strategy">

--- a/console/src/main/resources/org/togglz/console/index.html
+++ b/console/src/main/resources/org/togglz/console/index.html
@@ -67,8 +67,8 @@
                 ${end}
               </td>
               <td class="feature-actions">
-                <a href="edit?f=${feature.name}" title="Edit ${feature.label} feature">
-                  <span class="glyphicon glyphicon-lg glyphicon-cog text-muted"></span>
+                <a class="btn btn-sm btn-default" href="edit?f=${feature.name}" title="Edit ${feature.label} feature">
+                  <span class="glyphicon glyphicon-cog text-muted"></span>
                 </a>
               </td>
             </tr>

--- a/console/src/main/resources/org/togglz/console/template.html
+++ b/console/src/main/resources/org/togglz/console/template.html
@@ -11,11 +11,8 @@
   </head>
   <body>
     <div class="container">
-      <div class="page-header text-center">
-        <h1>Togglz</h1>
-        ${if displayName}
-        <h2>${displayName}</h2>
-        ${end}
+      <div class="page-header">
+        <h1>Togglz ${if displayName}<small>${displayName}</small>${end}</h1>
       </div>
       <div class="row">
         <div class="col-sm-12">


### PR DESCRIPTION
This pull request contains styling changes and addresses issue #60 

## Styling changes
* Modified page header to be displayed as intended
* Fix `Edit page` validation error css class (was `error` instead of `danger`)
* Edit icons on the index page are now displayed as buttons
* State icons were replaced by buttons (clicking changes feature state immediately)

Any opinions and/or wishes? 