### PR TITLE
Add support for configuring features via Spring Environment

### DIFF
--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -13,7 +13,7 @@
   <description>Togglz - Spring Boot Starter</description>
 
   <properties>
-    <spring-boot.version>1.5.1.RELEASE</spring-boot.version>
+    <spring-boot.version>1.5.4.RELEASE</spring-boot.version>
     <thymeleaf-togglz.version>1.0.1.RELEASE</thymeleaf-togglz.version>
   </properties>
 
@@ -120,30 +120,19 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
         <artifactId>spring-boot-starter-test</artifactId>
         <groupId>org.springframework.boot</groupId>
         <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-test</artifactId>
     </dependency>
 
   </dependencies>

--- a/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzAutoConfiguration.java
+++ b/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzAutoConfiguration.java
@@ -16,12 +16,19 @@
 
 package org.togglz.spring.boot.autoconfigure;
 
-import com.github.heneke.thymeleaf.togglz.TogglzDialect;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.Endpoint;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.*;
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -39,31 +46,26 @@ import org.togglz.console.TogglzConsoleServlet;
 import org.togglz.core.Feature;
 import org.togglz.core.activation.ActivationStrategyProvider;
 import org.togglz.core.activation.DefaultActivationStrategyProvider;
-import org.togglz.core.logging.Log;
-import org.togglz.core.logging.LogFactory;
-import org.togglz.core.manager.EmptyFeatureProvider;
+import org.togglz.core.manager.CompositeFeatureProvider;
 import org.togglz.core.manager.EnumBasedFeatureProvider;
 import org.togglz.core.manager.FeatureManager;
 import org.togglz.core.manager.FeatureManagerBuilder;
+import org.togglz.core.manager.PropertyFeatureProvider;
 import org.togglz.core.repository.StateRepository;
 import org.togglz.core.repository.cache.CachingStateRepository;
 import org.togglz.core.repository.composite.CompositeStateRepository;
 import org.togglz.core.repository.file.FileBasedStateRepository;
 import org.togglz.core.repository.mem.InMemoryStateRepository;
-import org.togglz.core.repository.property.PropertyBasedStateRepository;
-import org.togglz.core.repository.property.PropertySource;
 import org.togglz.core.spi.ActivationStrategy;
 import org.togglz.core.spi.FeatureProvider;
 import org.togglz.core.user.NoOpUserProvider;
 import org.togglz.core.user.UserProvider;
+import org.togglz.spring.boot.autoconfigure.TogglzProperties.FeatureSpec;
 import org.togglz.spring.listener.TogglzApplicationContextBinderApplicationListener;
 import org.togglz.spring.security.SpringSecurityUserProvider;
 import org.togglz.spring.web.FeatureInterceptor;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import com.github.heneke.thymeleaf.togglz.TogglzDialect;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Togglz.
@@ -75,214 +77,216 @@ import java.util.Properties;
 @EnableConfigurationProperties(TogglzProperties.class)
 public class TogglzAutoConfiguration {
 
-    private static final Log log = LogFactory.getLog(TogglzAutoConfiguration.class);
+	@Bean
+	public TogglzApplicationContextBinderApplicationListener togglzApplicationContextBinderApplicationListener() {
+		return new TogglzApplicationContextBinderApplicationListener();
+	}
 
-    @Bean
-    public TogglzApplicationContextBinderApplicationListener togglzApplicationContextBinderApplicationListener() {
-        return new TogglzApplicationContextBinderApplicationListener();
-    }
+	@Configuration
+	@ConditionalOnMissingBean(FeatureProvider.class)
+	protected static class FeatureProviderConfiguration {
 
-    @Configuration
-    @ConditionalOnMissingBean(FeatureProvider.class)
-    protected static class FeatureProviderConfiguration {
+		@Autowired
+		private TogglzProperties properties;
 
-        @Autowired
-        private TogglzProperties properties;
+		@Bean
+		public FeatureProvider featureProvider() {
+			PropertyFeatureProvider provider = new PropertyFeatureProvider(properties.getFeatureProperties());
+			Class<? extends Feature>[] featureEnums = properties.getFeatureEnums();
+			if (featureEnums != null && featureEnums.length > 0) {
+				return new CompositeFeatureProvider(new EnumBasedFeatureProvider(featureEnums), provider);
+			} else {
+				return provider;
+			}
+		}
+	}
 
-        @Bean
-        public FeatureProvider featureProvider() {
-            Class<? extends Feature>[] featureEnums = properties.getFeatureEnums();
-            if (featureEnums != null && featureEnums.length > 0) {
-                return new EnumBasedFeatureProvider(featureEnums);
-            } else {
-                log.warn("Creating a dummy feature provider as neither a FeatureProvider bean was provided nor the 'togglz.feature-enums' property was set!");
-                return new EmptyFeatureProvider();
-            }
-        }
-    }
+	@Configuration
+	@ConditionalOnMissingBean(FeatureManager.class)
+	protected static class FeatureManagerConfiguration {
 
-    @Configuration
-    @ConditionalOnMissingBean(FeatureManager.class)
-    protected static class FeatureManagerConfiguration {
+		@Autowired
+		private TogglzProperties properties;
 
-        @Autowired
-        private TogglzProperties properties;
+		@Bean
+		public FeatureManager featureManager(FeatureProvider featureProvider, List<StateRepository> stateRepositories,
+				UserProvider userProvider, ActivationStrategyProvider activationStrategyProvider) {
+			StateRepository stateRepository = null;
+			if (stateRepositories.size() == 1) {
+				stateRepository = stateRepositories.get(0);
+			} else if (stateRepositories.size() > 1) {
+				stateRepository = new CompositeStateRepository(
+						stateRepositories.toArray(new StateRepository[stateRepositories.size()]));
+			}
+			// If caching is enabled wrap state repository in caching state
+			// repository.
+			// Note that we explicitly check if the state repository is not
+			// already a caching state repository,
+			// as the auto configuration of the state repository already creates
+			// a caching state repository if needed.
+			// The below wrapping only occurs if the user provided the state
+			// repository manually and caching is enabled.
+			if (properties.getCache().isEnabled() && !(stateRepository instanceof CachingStateRepository)) {
+				stateRepository = new CachingStateRepository(stateRepository, properties.getCache().getTimeToLive(),
+						properties.getCache().getTimeUnit());
+			}
+			FeatureManagerBuilder featureManagerBuilder = new FeatureManagerBuilder();
+			String name = properties.getFeatureManagerName();
+			if (name != null && name.length() > 0) {
+				featureManagerBuilder.name(name);
+			}
+			featureManagerBuilder.featureProvider(featureProvider).stateRepository(stateRepository)
+					.userProvider(userProvider).activationStrategyProvider(activationStrategyProvider).build();
+			FeatureManager manager = featureManagerBuilder.build();
+			return manager;
+		}
+	}
 
-        @Bean
-        public FeatureManager featureManager(FeatureProvider featureProvider, List<StateRepository> stateRepositories, UserProvider userProvider, ActivationStrategyProvider activationStrategyProvider) {
-            StateRepository stateRepository = null;
-            if (stateRepositories.size() == 1) {
-                stateRepository = stateRepositories.get(0);
-            } else if (stateRepositories.size() > 1) {
-                stateRepository = new CompositeStateRepository(stateRepositories.toArray(new StateRepository[stateRepositories.size()]));
-            }
-            // If caching is enabled wrap state repository in caching state repository.
-            // Note that we explicitly check if the state repository is not already a caching state repository,
-            // as the auto configuration of the state repository already creates a caching state repository if needed.
-            // The below wrapping only occurs if the user provided the state repository manually and caching is enabled.
-            if (properties.getCache().isEnabled() && !(stateRepository instanceof CachingStateRepository)) {
-                stateRepository = new CachingStateRepository(stateRepository, properties.getCache().getTimeToLive(), properties.getCache().getTimeUnit());
-            }
-            FeatureManagerBuilder featureManagerBuilder = new FeatureManagerBuilder();
-            String name = properties.getFeatureManagerName();
-            if (name != null && name.length() > 0) {
-                featureManagerBuilder.name(name);
-            }
-            featureManagerBuilder
-                    .featureProvider(featureProvider)
-                    .stateRepository(stateRepository)
-                    .userProvider(userProvider)
-                    .activationStrategyProvider(activationStrategyProvider)
-                    .build();
-            return featureManagerBuilder.build();
-        }
-    }
+	@Configuration
+	@ConditionalOnMissingBean(ActivationStrategyProvider.class)
+	protected static class ActivationStrategyProviderConfiguration {
 
-    @Configuration
-    @ConditionalOnMissingBean(ActivationStrategyProvider.class)
-    protected static class ActivationStrategyProviderConfiguration {
+		@Autowired(required = false)
+		private List<ActivationStrategy> activationStrategies;
 
-        @Autowired(required = false)
-        private List<ActivationStrategy> activationStrategies;
+		@Bean
+		public ActivationStrategyProvider activationStrategyProvider() {
+			DefaultActivationStrategyProvider provider = new DefaultActivationStrategyProvider();
+			if (activationStrategies != null && activationStrategies.size() > 0) {
+				provider.addActivationStrategies(activationStrategies);
+			}
+			return provider;
+		}
+	}
 
-        @Bean
-        public ActivationStrategyProvider activationStrategyProvider() {
-            DefaultActivationStrategyProvider provider = new DefaultActivationStrategyProvider();
-            if (activationStrategies != null && activationStrategies.size() > 0) {
-                provider.addActivationStrategies(activationStrategies);
-            }
-            return provider;
-        }
-    }
+	@Configuration
+	@ConditionalOnMissingBean(StateRepository.class)
+	protected static class StateRepositoryConfiguration {
 
-    @Configuration
-    @ConditionalOnMissingBean(StateRepository.class)
-    protected static class StateRepositoryConfiguration {
+		@Autowired
+		private ResourceLoader resourceLoader = new DefaultResourceLoader();
 
-        @Autowired
-        private ResourceLoader resourceLoader = new DefaultResourceLoader();
+		@Autowired
+		private TogglzProperties properties;
 
-        @Autowired
-        private TogglzProperties properties;
+		@Bean
+		public StateRepository stateRepository() throws IOException {
+			StateRepository stateRepository;
+			String featuresFile = properties.getFeaturesFile();
+			if (featuresFile != null) {
+				Resource resource = this.resourceLoader.getResource(featuresFile);
+				Integer minCheckInterval = properties.getFeaturesFileMinCheckInterval();
+				if (minCheckInterval != null) {
+					stateRepository = new FileBasedStateRepository(resource.getFile(), minCheckInterval);
+				} else {
+					stateRepository = new FileBasedStateRepository(resource.getFile());
+				}
+			} else {
+				Map<String, FeatureSpec> features = properties.getFeatures();
+				stateRepository = new InMemoryStateRepository();
+				for (String name : features.keySet()) {
+					stateRepository.setFeatureState(features.get(name).state(name));
+				}
+			}
+			// If caching is enabled wrap state repository in caching state
+			// repository.
+			if (properties.getCache().isEnabled()) {
+				stateRepository = new CachingStateRepository(stateRepository, properties.getCache().getTimeToLive(),
+						properties.getCache().getTimeUnit());
+			}
+			return stateRepository;
+		}
+	}
 
-        @Bean
-        public StateRepository stateRepository() throws IOException {
-            StateRepository stateRepository;
-            Map<String, String> features = properties.getFeatures();
-            String featuresFile = properties.getFeaturesFile();
-            if (featuresFile != null) {
-                Resource resource = this.resourceLoader.getResource(featuresFile);
-                Integer minCheckInterval = properties.getFeaturesFileMinCheckInterval();
-                if (minCheckInterval != null) {
-                    stateRepository = new FileBasedStateRepository(resource.getFile(), minCheckInterval);
-                } else {
-                    stateRepository = new FileBasedStateRepository(resource.getFile());
-                }
-            } else if (features != null && features.size() > 0) {
-                Properties props = new Properties();
-                props.putAll(features);
-                PropertySource propertySource = new PropertiesPropertySource(props);
-                stateRepository = new PropertyBasedStateRepository(propertySource);
-            } else {
-                stateRepository = new InMemoryStateRepository();
-            }
-            // If caching is enabled wrap state repository in caching state repository.
-            if (properties.getCache().isEnabled()) {
-                stateRepository = new CachingStateRepository(stateRepository, properties.getCache().getTimeToLive(), properties.getCache().getTimeUnit());
-            }
-            return stateRepository;
-        }
-    }
+	@Configuration
+	@ConditionalOnMissingClass("org.springframework.security.config.annotation.web.configuration.EnableWebSecurity")
+	@ConditionalOnMissingBean(UserProvider.class)
+	protected static class UserProviderConfiguration {
+		@Bean
+		public UserProvider userProvider() {
+			return new NoOpUserProvider();
+		}
+	}
 
-    @Configuration
-    @ConditionalOnMissingClass("org.springframework.security.config.annotation.web.configuration.EnableWebSecurity")
-    @ConditionalOnMissingBean(UserProvider.class)
-    protected static class UserProviderConfiguration {
-        @Bean
-        public UserProvider userProvider() {
-            return new NoOpUserProvider();
-        }
-    }
+	@Configuration
+	@ConditionalOnClass({ EnableWebSecurity.class, AuthenticationEntryPoint.class, SpringSecurityUserProvider.class })
+	@ConditionalOnMissingBean(UserProvider.class)
+	protected static class SpringSecurityUserProviderConfiguration {
 
-    @Configuration
-    @ConditionalOnClass({EnableWebSecurity.class, AuthenticationEntryPoint.class, SpringSecurityUserProvider.class})
-    @ConditionalOnMissingBean(UserProvider.class)
-    protected static class SpringSecurityUserProviderConfiguration {
+		@Autowired
+		private TogglzProperties properties;
 
-        @Autowired
-        private TogglzProperties properties;
+		@Bean
+		public UserProvider userProvider() {
+			return new SpringSecurityUserProvider(properties.getConsole().getFeatureAdminAuthority());
+		}
+	}
 
-        @Bean
-        public UserProvider userProvider() {
-            return new SpringSecurityUserProvider(properties.getConsole().getFeatureAdminAuthority());
-        }
-    }
+	@Configuration
+	@ConditionalOnWebApplication
+	@ConditionalOnClass(TogglzConsoleServlet.class)
+	@Conditional(OnConsoleAndNotUseManagementPort.class)
+	protected static class TogglzConsoleConfiguration {
 
-    @Configuration
-    @ConditionalOnWebApplication
-    @ConditionalOnClass(TogglzConsoleServlet.class)
-    @Conditional(OnConsoleAndNotUseManagementPort.class)
-    protected static class TogglzConsoleConfiguration {
+		@Autowired
+		private TogglzProperties properties;
 
-        @Autowired
-        private TogglzProperties properties;
+		@Bean
+		public ServletRegistrationBean togglzConsole() {
+			String path = properties.getConsole().getPath();
+			String urlMapping = (path.endsWith("/") ? path + "*" : path + "/*");
+			TogglzConsoleServlet servlet = new TogglzConsoleServlet();
+			servlet.setSecured(properties.getConsole().isSecured());
+			return new ServletRegistrationBean(servlet, urlMapping);
+		}
+	}
 
-        @Bean
-        public ServletRegistrationBean togglzConsole() {
-            String path = properties.getConsole().getPath();
-            String urlMapping = (path.endsWith("/") ? path + "*" : path + "/*");
-            TogglzConsoleServlet servlet = new TogglzConsoleServlet();
-            servlet.setSecured(properties.getConsole().isSecured());
-            return new ServletRegistrationBean(servlet, urlMapping);
-        }
-    }
+	static class OnConsoleAndNotUseManagementPort extends AllNestedConditions {
 
-    static class OnConsoleAndNotUseManagementPort extends AllNestedConditions {
+		OnConsoleAndNotUseManagementPort() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
 
-        OnConsoleAndNotUseManagementPort() {
-            super(ConfigurationPhase.REGISTER_BEAN);
-        }
+		@ConditionalOnProperty(prefix = "togglz.console", name = "enabled", matchIfMissing = true)
+		static class OnConsole {
+		}
 
-        @ConditionalOnProperty(prefix = "togglz.console", name = "enabled", matchIfMissing = true)
-        static class OnConsole {
-        }
+		@ConditionalOnProperty(prefix = "togglz.console", name = "use-management-port", havingValue = "false")
+		static class OnNotUseManagementPort {
+		}
 
-        @ConditionalOnProperty(prefix = "togglz.console", name = "use-management-port", havingValue = "false")
-        static class OnNotUseManagementPort {
-        }
+	}
 
-    }
+	@Configuration
+	@ConditionalOnWebApplication
+	@ConditionalOnClass(HandlerInterceptorAdapter.class)
+	@ConditionalOnProperty(prefix = "togglz.web", name = "registerFeatureInterceptor", havingValue = "true")
+	protected static class TogglzFeatureInterceptorConfiguration extends WebMvcConfigurerAdapter {
+		@Override
+		public void addInterceptors(InterceptorRegistry registry) {
+			registry.addInterceptor(new FeatureInterceptor());
+		}
+	}
 
-    @Configuration
-    @ConditionalOnWebApplication
-    @ConditionalOnClass(HandlerInterceptorAdapter.class)
-    @ConditionalOnProperty(prefix = "togglz.web", name = "registerFeatureInterceptor", havingValue = "true")
-    protected static class TogglzFeatureInterceptorConfiguration extends WebMvcConfigurerAdapter {
-        @Override
-        public void addInterceptors(InterceptorRegistry registry) {
-            registry.addInterceptor(new FeatureInterceptor());
-        }
-    }
+	@Configuration
+	@ConditionalOnClass(Endpoint.class)
+	@ConditionalOnMissingBean(TogglzEndpoint.class)
+	@ConditionalOnProperty(prefix = "togglz.endpoint", name = "enabled", matchIfMissing = true)
+	protected static class TogglzEndpointConfiguration {
+		@Bean
+		public TogglzEndpoint togglzEndpoint(FeatureManager featureManager) {
+			return new TogglzEndpoint(featureManager);
+		}
+	}
 
-    @Configuration
-    @ConditionalOnClass(Endpoint.class)
-    @ConditionalOnMissingBean(TogglzEndpoint.class)
-    @ConditionalOnProperty(prefix = "togglz.endpoint", name = "enabled", matchIfMissing = true)
-    protected static class TogglzEndpointConfiguration {
-        @Bean
-        public TogglzEndpoint togglzEndpoint(FeatureManager featureManager) {
-            return new TogglzEndpoint(featureManager);
-        }
-    }
+	@Configuration
+	@ConditionalOnClass(TogglzDialect.class)
+	protected static class ThymeleafTogglzDialectConfiguration {
 
-    @Configuration
-    @ConditionalOnClass(TogglzDialect.class)
-    protected static class ThymeleafTogglzDialectConfiguration {
-
-        @Bean
-        @ConditionalOnMissingBean
-        public TogglzDialect togglzDialect() {
-            return new TogglzDialect();
-        }
-    }
+		@Bean
+		@ConditionalOnMissingBean
+		public TogglzDialect togglzDialect() {
+			return new TogglzDialect();
+		}
+	}
 }

--- a/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzEndpoint.java
+++ b/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzEndpoint.java
@@ -16,6 +16,11 @@
 
 package org.togglz.spring.boot.autoconfigure;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
 import org.springframework.boot.actuate.endpoint.Endpoint;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -23,10 +28,6 @@ import org.springframework.util.Assert;
 import org.togglz.core.Feature;
 import org.togglz.core.manager.FeatureManager;
 import org.togglz.core.repository.FeatureState;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 /**
  * {@link Endpoint} to expose Togglz info.
@@ -51,10 +52,11 @@ public class TogglzEndpoint extends AbstractEndpoint<List<TogglzEndpoint.TogglzF
             FeatureState featureState = this.featureManager.getFeatureState(feature);
             features.add(new TogglzFeature(feature, featureState));
         }
+        Collections.sort(features);
         return features;
     }
 
-    public static class TogglzFeature {
+    public static class TogglzFeature implements Comparable<TogglzFeature> {
 
         private String name;
         private boolean enabled;
@@ -83,5 +85,10 @@ public class TogglzEndpoint extends AbstractEndpoint<List<TogglzEndpoint.TogglzF
         public Map<String, String> getParams() {
             return params;
         }
+
+		@Override
+		public int compareTo(TogglzFeature o) {
+			return name.compareTo(o.getName());
+		}
     }
 }

--- a/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzProperties.java
+++ b/spring-boot-starter/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzProperties.java
@@ -16,15 +16,22 @@
 
 package org.togglz.spring.boot.autoconfigure;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.togglz.core.Feature;
-
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+import org.togglz.core.Feature;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.util.NamedFeature;
 
 /**
  * Configuration properties for Togglz.
@@ -34,291 +41,396 @@ import javax.validation.constraints.Pattern;
 @ConfigurationProperties(prefix = "togglz", ignoreUnknownFields = true)
 public class TogglzProperties {
 
-    /**
-     * Enable Togglz for the application.
-     */
-    private boolean enabled = true;
-
-    /**
-     * Comma-separated list of fully-qualified feature enum class names.
-     */
-    private Class<? extends Feature>[] featureEnums;
-
-    /**
-     * The name of the feature manager.
-     */
-    private String featureManagerName;
-
-    /**
-     * The feature states. Only needed if feature states are stored in application properties.
-     */
-    private Map<String, String> features;
-
-    /**
-     * The path to the features file that contains the feature states. Only needed if feature states are stored in external properties file.
-     */
-    private String featuresFile;
-
-    /**
-     * The minimum amount of time in milliseconds to wait between checks of the file's modification date.
-     */
-    private Integer featuresFileMinCheckInterval;
-
-    /**
-     * Feature state caching.
-     */
-    private Cache cache = new Cache();
-
-    @Valid
-    private Console console = new Console();
-
-    /**
-     * Togglz actuator endpoint.
-     */
-    private Endpoint endpoint = new Endpoint();
-
-    private Web web = new Web();
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public Class<? extends Feature>[] getFeatureEnums() {
-        return featureEnums;
-    }
-
-    public void setFeatureEnums(Class<? extends Feature>[] featureEnums) {
-        this.featureEnums = featureEnums;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public String getFeatureManagerName() {
-        return featureManagerName;
-    }
-
-    public void setFeatureManagerName(String featureManagerName) {
-        this.featureManagerName = featureManagerName;
-    }
-
-    public Map<String, String> getFeatures() {
-        return features;
-    }
-
-    public void setFeatures(Map<String, String> features) {
-        this.features = features;
-    }
-
-    public String getFeaturesFile() {
-        return featuresFile;
-    }
-
-    public void setFeaturesFile(String featuresFile) {
-        this.featuresFile = featuresFile;
-    }
-
-    public Integer getFeaturesFileMinCheckInterval() {
-        return featuresFileMinCheckInterval;
-    }
-
-    public void setFeaturesFileMinCheckInterval(Integer featuresFileMinCheckInterval) {
-        this.featuresFileMinCheckInterval = featuresFileMinCheckInterval;
-    }
-
-    public Cache getCache() {
-        return cache;
-    }
-
-    public void setCache(Cache cache) {
-        this.cache = cache;
-    }
-
-    public Console getConsole() {
-        return console;
-    }
-
-    public void setConsole(Console console) {
-        this.console = console;
-    }
-
-    public Endpoint getEndpoint() {
-        return endpoint;
-    }
-
-    public void setEndpoint(Endpoint endpoint) {
-        this.endpoint = endpoint;
-    }
-
-    public static class Cache {
-
-        /**
-         * Enable feature state caching.
-         */
-        private boolean enabled = false;
-
-        /**
-         * The time after which a cache entry will expire.
-         */
-        private long timeToLive = 0;
-
-        /**
-         * The time unit as java.util.concurrent.TimeUnit enum name (one of "nanoseconds", "microseconds", "milliseconds", "seconds", "minutes", "hours", "days").
-         */
-        private TimeUnit timeUnit = TimeUnit.MILLISECONDS;
-
-        public boolean isEnabled() {
-            return enabled;
-        }
-
-        public void setEnabled(boolean enabled) {
-            this.enabled = enabled;
-        }
-
-        public long getTimeToLive() {
-            return timeToLive;
-        }
-
-        public void setTimeToLive(long timeToLive) {
-            this.timeToLive = timeToLive;
-        }
-
-        public TimeUnit getTimeUnit() {
-            return timeUnit;
-        }
-
-        public void setTimeUnit(TimeUnit timeUnit) {
-            this.timeUnit = timeUnit;
-        }
-    }
-
-    public static class Console {
-
-        /**
-         * Enable admin console.
-         */
-        private boolean enabled = true;
-
-        /**
-         * The path of the admin console when enabled.
-         */
-        @NotNull
-        @Pattern(regexp = "/[^?#]*", message = "Path must start with /")
-        private String path = "/togglz-console";
-
-        /**
-         * The name of the authority that is allowed to access the admin console.
-         */
-        private String featureAdminAuthority;
-
-        /**
-         * Indicates if the admin console runs in secured mode. If false the application itself should take care of securing the admin console.
-         */
-        private boolean secured = true;
-
-        /**
-         * Indicates if the admin console runs on the management port.
-         */
-        private boolean useManagementPort = true;
-
-        public boolean isEnabled() {
-            return enabled;
-        }
-
-        public void setEnabled(boolean enabled) {
-            this.enabled = enabled;
-        }
-
-        public String getPath() {
-            return path;
-        }
-
-        public void setPath(String path) {
-            this.path = path;
-        }
-
-        public String getFeatureAdminAuthority() {
-            return featureAdminAuthority;
-        }
-
-        public void setFeatureAdminAuthority(String featureAdminAuthority) {
-            this.featureAdminAuthority = featureAdminAuthority;
-        }
-
-        public boolean isSecured() {
-            return secured;
-        }
-
-        public void setSecured(boolean secured) {
-            this.secured = secured;
-        }
-
-        public boolean isUseManagementPort() {
-            return useManagementPort;
-        }
-
-        public void setUseManagementPort(boolean useManagementPort) {
-            this.useManagementPort = useManagementPort;
-        }
-    }
-
-    public static class Web {
-
-        /**
-         * Register the FeatureInterceptor that allows you to activate a controller or contoller methods
-         * based on features.
-         */
-        private boolean registerFeatureInterceptor = false;
-
-        public boolean isRegisterFeatureInterceptor() {
-            return registerFeatureInterceptor;
-        }
-
-        public void setRegisterFeatureInterceptor(boolean registerFeatureInterceptor) {
-            this.registerFeatureInterceptor = registerFeatureInterceptor;
-        }
-    }
-
-    public static class Endpoint {
-
-        /**
-         * The endpoint identifier.
-         */
-        private String id = "togglz";
-
-        /**
-         * Enable actuator endpoint.
-         */
-        private boolean enabled = true;
-
-        /**
-         * Indicates if the endpoint exposes sensitive information.
-         */
-        private boolean sensitive = true;
-
-        public String getId() {
-            return id;
-        }
-
-        public void setId(String id) {
-            this.id = id;
-        }
-
-        public boolean isEnabled() {
-            return enabled;
-        }
-
-        public void setEnabled(boolean enabled) {
-            this.enabled = enabled;
-        }
-
-        public boolean isSensitive() {
-            return sensitive;
-        }
-
-        public void setSensitive(boolean sensitive) {
-            this.sensitive = sensitive;
-        }
-    }
+	/**
+	 * Enable Togglz for the application.
+	 */
+	private boolean enabled = true;
+
+	/**
+	 * Optional comma-separated list of fully-qualified feature enum class
+	 * names. Features can also be specified using the features property.
+	 */
+	private Class<? extends Feature>[] featureEnums;
+
+	/**
+	 * The name of the feature manager.
+	 */
+	private String featureManagerName;
+
+	/**
+	 * The features and their states. Only needed if feature states are stored
+	 * in application properties.
+	 */
+	private Map<String, FeatureSpec> features = new LinkedHashMap<>();
+
+	/**
+	 * The path to the features file that contains the feature states. Only
+	 * needed if feature states are stored in external properties file.
+	 */
+	private String featuresFile;
+
+	/**
+	 * The minimum amount of time in milliseconds to wait between checks of the
+	 * file's modification date.
+	 */
+	private Integer featuresFileMinCheckInterval;
+
+	/**
+	 * Feature state caching.
+	 */
+	private Cache cache = new Cache();
+
+	@Valid
+	private Console console = new Console();
+
+	/**
+	 * Togglz actuator endpoint.
+	 */
+	private Endpoint endpoint = new Endpoint();
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public Class<? extends Feature>[] getFeatureEnums() {
+		return featureEnums;
+	}
+
+	public void setFeatureEnums(Class<? extends Feature>[] featureEnums) {
+		this.featureEnums = featureEnums;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getFeatureManagerName() {
+		return featureManagerName;
+	}
+
+	public void setFeatureManagerName(String featureManagerName) {
+		this.featureManagerName = featureManagerName;
+	}
+
+	public Map<String, FeatureSpec> getFeatures() {
+		return features;
+	}
+
+	public void setFeatures(Map<String, FeatureSpec> features) {
+		this.features = features;
+	}
+
+	public String getFeaturesFile() {
+		return featuresFile;
+	}
+
+	public void setFeaturesFile(String featuresFile) {
+		this.featuresFile = featuresFile;
+	}
+
+	public Integer getFeaturesFileMinCheckInterval() {
+		return featuresFileMinCheckInterval;
+	}
+
+	public void setFeaturesFileMinCheckInterval(Integer featuresFileMinCheckInterval) {
+		this.featuresFileMinCheckInterval = featuresFileMinCheckInterval;
+	}
+
+	public Cache getCache() {
+		return cache;
+	}
+
+	public void setCache(Cache cache) {
+		this.cache = cache;
+	}
+
+	public Console getConsole() {
+		return console;
+	}
+
+	public void setConsole(Console console) {
+		this.console = console;
+	}
+
+	public Endpoint getEndpoint() {
+		return endpoint;
+	}
+
+	public void setEndpoint(Endpoint endpoint) {
+		this.endpoint = endpoint;
+	}
+
+	public static class FeatureSpec {
+		/**
+		 * Flag to say that the feature is enabled.
+		 */
+		private boolean enabled;
+
+		/**
+		 * Label for the feature in a UI.
+		 */
+		private String label;
+
+		/**
+		 * Optional strategy ID to identify the activation strategey to use for this feature.
+		 */
+		private String strategy;
+
+		/**
+		 * Names of the groups that this feature belongs to (optional).
+		 */
+		private Set<String> groups = new LinkedHashSet<>();
+
+		/**
+		 * Parameters that can be used by the activation strategy.
+		 */
+		private Map<String, String> param = new LinkedHashMap<>();
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public String getLabel() {
+			return label;
+		}
+
+		public void setLabel(String label) {
+			this.label = label;
+		}
+
+		public String getStrategy() {
+			return strategy;
+		}
+
+		public void setStrategy(String strategy) {
+			this.strategy = strategy;
+		}
+
+		public Set<String> getGroups() {
+			return groups;
+		}
+
+		public Map<String, String> getParam() {
+			return param;
+		}
+
+		public FeatureState state(String name) {
+			FeatureState state = new FeatureState(feature(name), enabled);
+			for (String key : param.keySet()) {
+				state.setParameter(key, param.get(key));
+			}
+			if (StringUtils.hasText(strategy)) {
+				state.setStrategyId(strategy);
+			}
+			return state;
+		}
+
+		public Feature feature(String name) {
+			return new NamedFeature(name);
+		}
+
+		public String spec() {
+			return (label == null ? "" : label) + ";" + enabled
+					+ (groups.isEmpty() ? "" : ";" + StringUtils.collectionToCommaDelimitedString(groups));
+		}
+
+		@Override
+		public String toString() {
+			return "FeatureSpec [label=" + label + ", enabled=" + enabled + ", groups=" + groups + ", strategy="
+					+ strategy + ", param=" + param + "]";
+		}
+	}
+
+	public static class Cache {
+
+		/**
+		 * Enable feature state caching.
+		 */
+		private boolean enabled = false;
+
+		/**
+		 * The time after which a cache entry will expire.
+		 */
+		private long timeToLive = 0;
+
+		/**
+		 * The time unit as java.util.concurrent.TimeUnit enum name (one of
+		 * "nanoseconds", "microseconds", "milliseconds", "seconds", "minutes",
+		 * "hours", "days").
+		 */
+		private TimeUnit timeUnit = TimeUnit.MILLISECONDS;
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public long getTimeToLive() {
+			return timeToLive;
+		}
+
+		public void setTimeToLive(long timeToLive) {
+			this.timeToLive = timeToLive;
+		}
+
+		public TimeUnit getTimeUnit() {
+			return timeUnit;
+		}
+
+		public void setTimeUnit(TimeUnit timeUnit) {
+			this.timeUnit = timeUnit;
+		}
+	}
+
+	public static class Console {
+
+		/**
+		 * Enable admin console.
+		 */
+		private boolean enabled = true;
+
+		/**
+		 * The path of the admin console when enabled.
+		 */
+		@NotNull
+		@Pattern(regexp = "/[^?#]*", message = "Path must start with /")
+		private String path = "/togglz-console";
+
+		/**
+		 * The name of the authority that is allowed to access the admin
+		 * console.
+		 */
+		private String featureAdminAuthority;
+
+		/**
+		 * Indicates if the admin console runs in secured mode. If false the
+		 * application itself should take care of securing the admin console.
+		 */
+		private boolean secured = true;
+
+		/**
+		 * Indicates if the admin console runs on the management port.
+		 */
+		private boolean useManagementPort = true;
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public String getPath() {
+			return path;
+		}
+
+		public void setPath(String path) {
+			this.path = path;
+		}
+
+		public String getFeatureAdminAuthority() {
+			return featureAdminAuthority;
+		}
+
+		public void setFeatureAdminAuthority(String featureAdminAuthority) {
+			this.featureAdminAuthority = featureAdminAuthority;
+		}
+
+		public boolean isSecured() {
+			return secured;
+		}
+
+		public void setSecured(boolean secured) {
+			this.secured = secured;
+		}
+
+		public boolean isUseManagementPort() {
+			return useManagementPort;
+		}
+
+		public void setUseManagementPort(boolean useManagementPort) {
+			this.useManagementPort = useManagementPort;
+		}
+	}
+
+	public static class Web {
+
+		/**
+		 * Register the FeatureInterceptor that allows you to activate a
+		 * controller or contoller methods based on features.
+		 */
+		private boolean registerFeatureInterceptor = false;
+
+		public boolean isRegisterFeatureInterceptor() {
+			return registerFeatureInterceptor;
+		}
+
+		public void setRegisterFeatureInterceptor(boolean registerFeatureInterceptor) {
+			this.registerFeatureInterceptor = registerFeatureInterceptor;
+		}
+	}
+
+	public static class Endpoint {
+
+		/**
+		 * The endpoint identifier.
+		 */
+		private String id = "togglz";
+
+		/**
+		 * Enable actuator endpoint.
+		 */
+		private boolean enabled = true;
+
+		/**
+		 * Indicates if the endpoint exposes sensitive information.
+		 */
+		private boolean sensitive = true;
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public boolean isSensitive() {
+			return sensitive;
+		}
+
+		public void setSensitive(boolean sensitive) {
+			this.sensitive = sensitive;
+		}
+	}
+
+	/**
+	 * The configured features in a format that can be consumed by a
+	 * PropertyFeatureProvider.
+	 * 
+	 * @return features in the right format.
+	 */
+	public Properties getFeatureProperties() {
+		Properties properties = new Properties();
+		for (String name : features.keySet()) {
+			properties.setProperty(name, features.get(name).spec());
+		}
+		return properties;
+	}
 }

--- a/spring-boot-starter/src/main/java/org/togglz/spring/boot/test/TogglzTestExecutionListener.java
+++ b/spring-boot-starter/src/main/java/org/togglz/spring/boot/test/TogglzTestExecutionListener.java
@@ -1,0 +1,30 @@
+package org.togglz.spring.boot.test;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+import org.togglz.core.Feature;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.repository.FeatureState;
+
+public class TogglzTestExecutionListener extends AbstractTestExecutionListener {
+
+	@Override
+	public void beforeTestMethod(TestContext testContext) throws Exception {
+		ApplicationContext context = testContext.getApplicationContext();
+		if (context.getBeanNamesForType(FeatureManager.class).length!=1) {
+			return;
+		}
+		FeatureManager manager = context.getBean(FeatureManager.class);
+		for (Feature feature : manager.getFeatures()) {
+			FeatureState defaults = manager.getMetaData(feature).getDefaultFeatureState();
+			FeatureState state = manager.getFeatureState(feature);
+			if (defaults.isEnabled()) {
+				state.enable();
+			} else {
+				state.disable();
+			}
+			manager.setFeatureState(state);
+		}
+	}
+}

--- a/spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -4,3 +4,7 @@ org.togglz.spring.boot.autoconfigure.TogglzAutoConfiguration
 
 org.springframework.boot.actuate.autoconfigure.ManagementContextConfiguration=\
 org.togglz.spring.boot.autoconfigure.TogglzManagementContextConfiguration
+
+# Test Execution Listeners
+org.springframework.test.context.TestExecutionListener=\
+org.togglz.spring.boot.test.TogglzTestExecutionListener

--- a/spring-boot-starter/src/test/java/org/togglz/spring/boot/autoconfigure/TogglzAutoConfigurationTest.java
+++ b/spring-boot-starter/src/test/java/org/togglz/spring/boot/autoconfigure/TogglzAutoConfigurationTest.java
@@ -16,6 +16,18 @@
 
 package org.togglz.spring.boot.autoconfigure;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.BeanCreationException;
@@ -28,27 +40,19 @@ import org.springframework.web.context.support.AnnotationConfigWebApplicationCon
 import org.togglz.core.Feature;
 import org.togglz.core.activation.Parameter;
 import org.togglz.core.context.FeatureContext;
-import org.togglz.core.manager.EmptyFeatureProvider;
 import org.togglz.core.manager.EnumBasedFeatureProvider;
 import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.manager.PropertyFeatureProvider;
 import org.togglz.core.repository.FeatureState;
 import org.togglz.core.repository.StateRepository;
 import org.togglz.core.repository.cache.CachingStateRepository;
 import org.togglz.core.repository.file.FileBasedStateRepository;
 import org.togglz.core.repository.mem.InMemoryStateRepository;
-import org.togglz.core.repository.property.PropertyBasedStateRepository;
 import org.togglz.core.spi.ActivationStrategy;
 import org.togglz.core.spi.FeatureProvider;
 import org.togglz.core.user.FeatureUser;
 import org.togglz.core.user.UserProvider;
 import org.togglz.spring.util.ContextClassLoaderApplicationContextHolder;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-
-import static org.junit.Assert.*;
 
 /**
  * Tests for {@link TogglzAutoConfiguration}.
@@ -119,7 +123,7 @@ public class TogglzAutoConfigurationTest {
     @Test
     public void noFeatureProviderBeanAndFeatureEnumsProperty() {
         loadWithDefaults();
-        assertTrue(this.context.getBean(FeatureProvider.class) instanceof EmptyFeatureProvider);
+        assertTrue(this.context.getBean(FeatureProvider.class) instanceof PropertyFeatureProvider);
     }
 
     @Test
@@ -148,12 +152,12 @@ public class TogglzAutoConfigurationTest {
     @Test
     public void features() {
         loadWithDefaults(new Class[]{FeatureProviderConfig.class},
-                "togglz.features.FEATURE_ONE: true",
-                "togglz.features.FEATURE_TWO: false");
+                "togglz.features.FEATURE_ONE.enabled: true",
+                "togglz.features.FEATURE_TWO.enabled: false");
         FeatureManager featureManager = this.context.getBean(FeatureManager.class);
         assertTrue(featureManager.isActive(MyFeatures.FEATURE_ONE));
         assertFalse(featureManager.isActive(MyFeatures.FEATURE_TWO));
-        assertTrue(this.context.getBean(StateRepository.class) instanceof PropertyBasedStateRepository);
+        assertTrue(this.context.getBean(StateRepository.class) instanceof InMemoryStateRepository);
     }
 
     @Test
@@ -309,7 +313,8 @@ public class TogglzAutoConfigurationTest {
     @Configuration
     protected static class FeatureProviderConfig {
 
-        @Bean
+        @SuppressWarnings("unchecked")
+		@Bean
         public FeatureProvider featureProvider() {
             return new EnumBasedFeatureProvider(MyFeatures.class);
         }

--- a/spring-boot-starter/src/test/java/org/togglz/spring/boot/autoconfigure/TogglzEndpointTest.java
+++ b/spring-boot-starter/src/test/java/org/togglz/spring/boot/autoconfigure/TogglzEndpointTest.java
@@ -16,20 +16,18 @@
 
 package org.togglz.spring.boot.autoconfigure;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.togglz.core.Feature;
-import org.togglz.core.manager.EnumBasedFeatureProvider;
-import org.togglz.core.spi.FeatureProvider;
-
-import java.util.List;
-
-import static org.junit.Assert.*;
 
 /**
  * Tests for {@link TogglzEndpoint}.
@@ -49,9 +47,9 @@ public class TogglzEndpointTest {
 
     @Test
     public void invoke() throws Exception {
-        load(new Class[]{FeatureProviderConfig.class, JacksonAutoConfiguration.class, TogglzAutoConfiguration.class},
-                "togglz.features.FEATURE_ONE: true",
-                "togglz.features.FEATURE_TWO: false",
+        load(new Class[]{JacksonAutoConfiguration.class, TogglzAutoConfiguration.class},
+                "togglz.features.FEATURE_ONE.enabled: true",
+                "togglz.features.FEATURE_TWO.enabled: false",
                 "togglz.features.FEATURE_TWO.strategy: release-date",
                 "togglz.features.FEATURE_TWO.param.date: 2016-07-01",
                 "togglz.features.FEATURE_TWO.param.time: 08:30:00");
@@ -84,17 +82,4 @@ public class TogglzEndpointTest {
         this.context.refresh();
     }
 
-    protected enum MyFeatures implements Feature {
-        FEATURE_ONE,
-        FEATURE_TWO;
-    }
-
-    @Configuration
-    protected static class FeatureProviderConfig {
-
-        @Bean
-        public FeatureProvider featureProvider() {
-            return new EnumBasedFeatureProvider(MyFeatures.class);
-        }
-    }
 }


### PR DESCRIPTION
This will be much more comfortable for Spring and Spring Boot users
since there are multiple ways to get properties into the
Environment (and using Spring Cloud you can update it at runtime
as well).

The only unfortunate side effect is that the existing configuration
at togglz.features.<FEATURE>=true|false had to be moved down a level,
i.e. togglz.features.<FEATURE>.enabled=true|false, so that the
other properties (strategy, groups, etc.) can all be bound to the same
object. Since this is 2.5.0 I hope that will be acceptable (people
using the existing configuration model will have to migrate).

I was going to add some documentation, but I couldn't find the source
code for that. Can someone point me at the right way to do it?