### PR TITLE
Add A URL Parameter Activation Strategy

### DIFF
--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -40,11 +40,6 @@
       <artifactId>togglz-test-harness</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
-    </dependency>
 
   </dependencies>
 </project>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -40,6 +40,11 @@
       <artifactId>togglz-test-harness</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.2</version>
+    </dependency>
 
   </dependencies>
 </project>

--- a/servlet/src/main/java/org/togglz/servlet/activation/UrlParameterActivationStrategy.java
+++ b/servlet/src/main/java/org/togglz/servlet/activation/UrlParameterActivationStrategy.java
@@ -54,7 +54,7 @@ public class UrlParameterActivationStrategy implements ActivationStrategy {
 		if (referer != null) {
 			try {
 				Map<String, List<String>> combinedRefererParameters = getRefererParameters(requestParams, referer);
-				
+
 				for (Map.Entry<String, List<String>> entry : combinedRefererParameters.entrySet()) {
 					List<String> val  = entry.getValue();
 					String[] values = new String[val.size()];

--- a/servlet/src/main/java/org/togglz/servlet/activation/UrlParameterActivationStrategy.java
+++ b/servlet/src/main/java/org/togglz/servlet/activation/UrlParameterActivationStrategy.java
@@ -1,0 +1,106 @@
+package org.togglz.servlet.activation;
+
+import org.togglz.core.activation.ParameterBuilder;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.spi.ActivationStrategy;
+import org.togglz.core.user.FeatureUser;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URIBuilder;
+import org.togglz.core.activation.Parameter;
+import org.togglz.core.util.Strings;
+import org.togglz.servlet.util.HttpServletRequestHolder;
+import javax.servlet.http.HttpServletRequest;
+
+public class UrlParameterActivationStrategy implements ActivationStrategy {
+	static final String PARAM_URL_PARAMS = "params";
+	private static final Pattern SPLIT_ON_COMMA = Pattern.compile("\\s*,\\s*");
+	private static final Pattern SPLIT_ON_EQUALS = Pattern.compile("\\s*=\\s*");
+
+	@Override
+	public String getId() {
+		return "url-parameter";
+	}
+
+	@Override
+	public String getName() {
+		return "URL Parameter";
+	}
+
+	@Override
+	public boolean isActive(FeatureState featureState, FeatureUser user) {
+		HttpServletRequest request = HttpServletRequestHolder.get();
+		if (request == null) {
+			return false;
+		}
+
+		String allowedUrlParams = featureState.getParameter(PARAM_URL_PARAMS);
+		if (Strings.isBlank(allowedUrlParams)) {
+			return false;
+		}
+
+		//Parse the request params and activation params and compare them for a match
+		String[] allowedParams = SPLIT_ON_COMMA.split(allowedUrlParams.trim());
+		Map<String, String[]> requestParams = new HashMap<>();
+		requestParams.putAll(request.getParameterMap());
+		String referer = request.getHeader("referer");
+		if (referer != null) {
+			try {
+				List<NameValuePair> refererParameters = new URIBuilder(referer).getQueryParams();
+				Map<String, List<String>> combinedRefererParameters = new HashMap<>();
+				for (NameValuePair pair : refererParameters) {
+					if (!requestParams.containsKey(pair.getName())) {
+						if (combinedRefererParameters.containsKey(pair.getName())) {
+							List<String> values = combinedRefererParameters.get(pair.getName());
+							values.add(pair.getValue());
+							combinedRefererParameters.put(pair.getName(), values);
+						} else {
+							combinedRefererParameters.put(pair.getName(), new ArrayList<>(Arrays.asList(pair.getValue())));
+						}
+					}
+				}
+				for (Map.Entry<String, List<String>> entry : combinedRefererParameters.entrySet()) {
+					List<String> val  = entry.getValue();
+					String[] values = new String[val.size()];
+					requestParams.put(entry.getKey(), val.toArray(values));
+				}
+			} catch (URISyntaxException e) {
+				e.printStackTrace();
+			}
+
+		}
+		for (String allowedParam : allowedParams) {
+			String[] paramData = SPLIT_ON_EQUALS.split(allowedParam, 2);
+			if (requestParams.containsKey(paramData[0])) {
+				if (paramData.length == 1) {
+					return true;
+				}
+				String[] paramValues = requestParams.get(paramData[0]);
+				if (paramValues != null) {
+					for (String paramValue : paramValues) {
+						if (Objects.equals(paramData[1], paramValue)) {
+							return true;
+						}
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	@Override
+	public Parameter[] getParameters() {
+		return new Parameter[]{
+				ParameterBuilder.create(PARAM_URL_PARAMS).label("URL Parameters")
+						.description("A comma-separated list of Name[=Value] pairs for which the feature should be active. Please choose unique names for your paramter(s). If no value is specified, simply having the parameter present will activate the toggle. \nImportant Note: Use unique parameter key/value pairs to avoid accidental activation.")
+		};
+	}
+}

--- a/servlet/src/main/java/org/togglz/servlet/activation/UrlParameterActivationStrategy.java
+++ b/servlet/src/main/java/org/togglz/servlet/activation/UrlParameterActivationStrategy.java
@@ -4,7 +4,12 @@ import org.togglz.core.activation.ParameterBuilder;
 import org.togglz.core.repository.FeatureState;
 import org.togglz.core.spi.ActivationStrategy;
 import org.togglz.core.user.FeatureUser;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -12,106 +17,127 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URIBuilder;
+
 import org.togglz.core.activation.Parameter;
 import org.togglz.core.util.Strings;
 import org.togglz.servlet.util.HttpServletRequestHolder;
+import org.togglz.core.logging.Log;
+import org.togglz.core.logging.LogFactory;
+
 import javax.servlet.http.HttpServletRequest;
 
 public class UrlParameterActivationStrategy implements ActivationStrategy {
-	public static final String PARAM_URL_PARAMS = "params";
-	private static final Pattern SPLIT_ON_COMMA = Pattern.compile("\\s*,\\s*");
-	private static final Pattern SPLIT_ON_EQUALS = Pattern.compile("\\s*=\\s*");
+    private final Log log = LogFactory.getLog(UrlParameterActivationStrategy.class);
+    public static final String PARAM_URL_PARAMS = "params";
+    private static final Pattern SPLIT_ON_COMMA = Pattern.compile("\\s*,\\s*");
+    private static final Pattern SPLIT_ON_EQUALS = Pattern.compile("\\s*=\\s*");
 
-	@Override
-	public String getId() {
-		return "url-parameter";
-	}
+    @Override
+    public String getId() {
+        return "url-parameter";
+    }
 
-	@Override
-	public String getName() {
-		return "URL Parameter";
-	}
+    @Override
+    public String getName() {
+        return "URL Parameter";
+    }
 
-	@Override
-	public boolean isActive(FeatureState featureState, FeatureUser user) {
-		HttpServletRequest request = HttpServletRequestHolder.get();
-		if (request == null) {
-			return false;
-		}
+    @Override
+    public boolean isActive(FeatureState featureState, FeatureUser user) {
+        HttpServletRequest request = HttpServletRequestHolder.get();
+        if (request == null) {
+            return false;
+        }
 
-		String allowedUrlParams = featureState.getParameter(PARAM_URL_PARAMS);
-		if (Strings.isBlank(allowedUrlParams)) {
-			return false;
-		}
+        String allowedUrlParams = featureState.getParameter(PARAM_URL_PARAMS);
+        if (Strings.isBlank(allowedUrlParams)) {
+            return false;
+        }
 
-		//Parse the request params and activation params and compare them for a match
-		String[] allowedParams = SPLIT_ON_COMMA.split(allowedUrlParams.trim());
-		Map<String, String[]> requestParams = new HashMap<>();
-		requestParams.putAll(request.getParameterMap());
-		String referer = request.getHeader("referer");
-		if (referer != null) {
-			try {
-				Map<String, List<String>> combinedRefererParameters = getRefererParameters(requestParams, referer);
+        //Parse the request params and activation params and compare them for a match
+        String[] allowedParams = SPLIT_ON_COMMA.split(allowedUrlParams.trim());
+        Map<String, String[]> requestParams = new HashMap<>();
+        requestParams.putAll(request.getParameterMap());
+        String referer = request.getHeader("referer");
+        if (referer != null) {
+            try {
+                Map<String, List<String>> combinedRefererParameters = getRefererParameters(requestParams, referer);
 
-				for (Map.Entry<String, List<String>> entry : combinedRefererParameters.entrySet()) {
-					List<String> val  = entry.getValue();
-					String[] values = new String[val.size()];
-					requestParams.put(entry.getKey(), val.toArray(values));
-				}
-			} catch (URISyntaxException e) {
-				e.printStackTrace();
-			}
+                for (Map.Entry<String, List<String>> entry : combinedRefererParameters.entrySet()) {
+                    List<String> val = entry.getValue();
+                    String[] values = new String[val.size()];
+                    requestParams.put(entry.getKey(), val.toArray(values));
+                }
+            } catch (Exception e) {
+                log.error("Error parsing referer for Togglz parameter activation", e);
+            }
+        }
 
-		}
+        return hasActivationUrlParameter(allowedParams, requestParams);
+    }
 
-		return hasActivationUrlParameter(allowedParams, requestParams);
-	}
+    private Map<String, List<String>> getRefererParameters(Map<String, String[]> requestParams, String referer)
+        throws URISyntaxException, UnsupportedEncodingException {
+        List<Map.Entry<String, String>> queryPairs = getParameterNameValuePairsFromURL(referer);
 
-	private Map<String, List<String>> getRefererParameters(Map<String, String[]> requestParams, String referer) throws URISyntaxException {
-		List<NameValuePair> refererParameters = new URIBuilder(referer).getQueryParams();
-		Map<String, List<String>> combinedRefererParameters = new HashMap<>();
-		for (NameValuePair pair : refererParameters) {
-			if (!requestParams.containsKey(pair.getName())) {
-				if (combinedRefererParameters.containsKey(pair.getName())) {
-					List<String> values = combinedRefererParameters.get(pair.getName());
-					values.add(pair.getValue());
-					combinedRefererParameters.put(pair.getName(), values);
-				} else {
-					combinedRefererParameters.put(pair.getName(), new ArrayList<>(Arrays.asList(pair.getValue())));
-				}
-			}
-		}
-		return combinedRefererParameters;
-	}
+        Map<String, List<String>> combinedRefererParameters = new HashMap<>();
+        for (Map.Entry<String, String> pair : queryPairs) {
+            if (!requestParams.containsKey(pair.getKey())) {
+                if (combinedRefererParameters.containsKey(pair.getKey())) {
+                    List<String> values = combinedRefererParameters.get(pair.getKey());
+                    values.add(pair.getValue());
+                    combinedRefererParameters.put(pair.getKey(), values);
+                } else {
+                    combinedRefererParameters.put(pair.getKey(), new ArrayList<>(Arrays.asList(pair.getValue())));
+                }
+            }
+        }
+        return combinedRefererParameters;
+    }
 
-	private boolean hasActivationUrlParameter(String[] allowedParams, Map<String, String[]> requestParams) {
-		for (String allowedParam : allowedParams) {
-			String[] paramData = SPLIT_ON_EQUALS.split(allowedParam, 2);
-			if (requestParams.containsKey(paramData[0])) {
-				if (paramData.length == 1) {
-					return true;
-				}
-				String[] paramValues = requestParams.get(paramData[0]);
-				if (paramValues != null) {
-					for (String paramValue : paramValues) {
-						if (Objects.equals(paramData[1], paramValue)) {
-							return true;
-						}
-					}
-				}
-			}
-		}
+    private List<Map.Entry<String, String>> getParameterNameValuePairsFromURL(String referer)
+        throws URISyntaxException, UnsupportedEncodingException {
+        List<Map.Entry<String, String>> queryPairs = new ArrayList<>();
+        URI uri = new URI(referer);
+        String[] pairs = uri.getQuery().split("&");
+        for (String pair : pairs) {
+            final int idx = pair.indexOf("=");
+            final String key = idx > 0 ? URLDecoder.decode(pair.substring(0, idx), "UTF-8") : pair;
+            final String value =
+                idx > 0 && pair.length() > idx + 1 ? URLDecoder.decode(pair.substring(idx + 1), "UTF-8") : null;
+            queryPairs.add(new AbstractMap.SimpleEntry<>(key, value));
 
-		return false;
-	}
+        }
+        return queryPairs;
+    }
 
-	@Override
-	public Parameter[] getParameters() {
-		return new Parameter[]{
-				ParameterBuilder.create(PARAM_URL_PARAMS).label("URL Parameters")
-						.description("A comma-separated list of Name[=Value] pairs for which the feature should be active. Please choose unique names for your paramter(s). If no value is specified, simply having the parameter present will activate the toggle. \nImportant Note: Use unique parameter key/value pairs to avoid accidental activation.")
-		};
-	}
+    private boolean hasActivationUrlParameter(String[] allowedParams, Map<String, String[]> requestParams) {
+        for (String allowedParam : allowedParams) {
+            String[] paramData = SPLIT_ON_EQUALS.split(allowedParam, 2);
+            if (requestParams.containsKey(paramData[0])) {
+                if (paramData.length == 1) {
+                    return true;
+                }
+                String[] paramValues = requestParams.get(paramData[0]);
+                if (paramValues != null) {
+                    for (String paramValue : paramValues) {
+                        if (Objects.equals(paramData[1], paramValue)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public Parameter[] getParameters() {
+        return new Parameter[] {
+            ParameterBuilder.create(PARAM_URL_PARAMS).label("URL Parameters")
+                .description(
+                "A comma-separated list of Name[=Value] pairs for which the feature should be active. Please choose unique names for your parameter(s). If no value is specified, simply having the parameter present will activate the toggle. \nImportant Note: Use unique parameter key/value pairs to avoid accidental activation.")
+        };
+    }
 }

--- a/servlet/src/test/java/org/togglz/servlet/activation/UrlParameterActivationStrategyTest.java
+++ b/servlet/src/test/java/org/togglz/servlet/activation/UrlParameterActivationStrategyTest.java
@@ -21,183 +21,199 @@ import java.util.Map;
 import static org.mockito.Mockito.when;
 
 public class UrlParameterActivationStrategyTest {
-	private FeatureUser user;
-	private FeatureState state;
-	private HttpServletRequest request;
-	private final UrlParameterActivationStrategy strategy = new UrlParameterActivationStrategy();
+    private FeatureUser user;
+    private FeatureState state;
+    private HttpServletRequest request;
+    private final UrlParameterActivationStrategy strategy = new UrlParameterActivationStrategy();
 
-	@Before
-	public void setUp() {
-		user = new SimpleFeatureUser("ea", false);
-		state = new FeatureState(MyFeature.FEATURE).enable();
-		state.setParameter(UrlParameterActivationStrategy.PARAM_URL_PARAMS, "toggleFeatureX=true,toggleAll=yes,parameterWithoutValue");
-		request = Mockito.mock(HttpServletRequest.class);
-		HttpServletRequestHolder.bind(request);
-	}
+    @Before
+    public void setUp() {
+        user = new SimpleFeatureUser("ea", false);
+        state = new FeatureState(MyFeature.FEATURE).enable();
+        state.setParameter(UrlParameterActivationStrategy.PARAM_URL_PARAMS,
+            "toggleFeatureX=true,toggleAll=yes,parameterWithoutValue");
+        request = Mockito.mock(HttpServletRequest.class);
+        HttpServletRequestHolder.bind(request);
+    }
 
-	@After
-	public void cleanup(){
-		HttpServletRequestHolder.release();
-	}
+    @After
+    public void cleanup() {
+        HttpServletRequestHolder.release();
+    }
 
-	private enum MyFeature implements Feature {
-		FEATURE
-	}
+    private enum MyFeature implements Feature {
+        FEATURE
+    }
 
-	@Test
-	public void shouldNotBeActiveWithANullRequestObject(){
-		HttpServletRequestHolder.release();
+    @Test
+    public void shouldNotBeActiveWithANullRequestObject() {
+        HttpServletRequestHolder.release();
 
-		boolean isActive = strategy.isActive(state, user);
+        boolean isActive = strategy.isActive(state, user);
 
-		Assert.assertFalse(isActive);
-	}
+        Assert.assertFalse(isActive);
+    }
 
-	@Test
-	public void shouldNotBeActiveWithNoPermittedParameters(){
-		when(request.getParameterMap()).thenReturn(Collections.EMPTY_MAP);
+    @Test
+    public void shouldNotBeActiveWithNoPermittedParameters() {
+        when(request.getParameterMap()).thenReturn(Collections.EMPTY_MAP);
 
-		boolean isActive = strategy.isActive(state, user);
+        boolean isActive = strategy.isActive(state, user);
 
-		Assert.assertFalse(isActive);
-	}
+        Assert.assertFalse(isActive);
+    }
 
-	@Test
-	public void shouldNotBeActiveWhenOnlyNonMatchingParametersArePresent(){
-		Map<String, String[]> parameters = new HashMap<>();
-		parameters.put("somethingThatDoesNotMatch", (String[]) Arrays.asList("true").toArray());
-		parameters.put("somethingElse", (String[]) Arrays.asList("aValue").toArray());
-		when(request.getParameterMap()).thenReturn(parameters);
+    @Test
+    public void shouldNotBeActiveWhenOnlyNonMatchingParametersArePresent() {
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("somethingThatDoesNotMatch", (String[]) Arrays.asList("true").toArray());
+        parameters.put("somethingElse", (String[]) Arrays.asList("aValue").toArray());
+        when(request.getParameterMap()).thenReturn(parameters);
 
-		boolean isActive = strategy.isActive(state, user);
+        boolean isActive = strategy.isActive(state, user);
 
-		Assert.assertFalse(isActive);
-	}
+        Assert.assertFalse(isActive);
+    }
 
-	@Test
-	public void shouldNotBeActiveWhenMatchingParameterHasANonMatchingValue(){
-		Map<String, String[]> parameters = new HashMap<>();
-		parameters.put("toggleFeatureX", (String[]) Arrays.asList("false").toArray());
-		parameters.put("toggleAll", (String[]) Arrays.asList("nope").toArray());
-		when(request.getParameterMap()).thenReturn(parameters);
+    @Test
+    public void shouldNotBeActiveWhenMatchingParameterHasANonMatchingValue() {
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("toggleFeatureX", (String[]) Arrays.asList("false").toArray());
+        parameters.put("toggleAll", (String[]) Arrays.asList("nope").toArray());
+        when(request.getParameterMap()).thenReturn(parameters);
 
-		boolean isActive = strategy.isActive(state, user);
+        boolean isActive = strategy.isActive(state, user);
 
-		Assert.assertFalse(isActive);
-	}
+        Assert.assertFalse(isActive);
+    }
 
-	@Test
-	public void shouldNotBeActiveWhenMatchingParameterRequiringValueDoesNotHaveValue(){
-		Map<String, String[]> parameters = new HashMap<>();
-		parameters.put("toggleFeatureX", null);
-		when(request.getParameterMap()).thenReturn(parameters);
+    @Test
+    public void shouldNotBeActiveWhenMatchingParameterRequiringValueDoesNotHaveValue() {
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("toggleFeatureX", null);
+        when(request.getParameterMap()).thenReturn(parameters);
 
-		boolean isActive = strategy.isActive(state, user);
+        boolean isActive = strategy.isActive(state, user);
 
-		Assert.assertFalse(isActive);
-	}
+        Assert.assertFalse(isActive);
+    }
 
-	@Test
-	public void shouldBeActiveWhenAnAcceptedParameterAndValueArePresent(){
-		Map<String, String[]> parameters = new HashMap<>();
-		parameters.put("toggleFeatureX", (String[]) Arrays.asList("true").toArray());
-		parameters.put("toggleAll", (String[]) Arrays.asList("nope").toArray());
-		when(request.getParameterMap()).thenReturn(parameters);
+    @Test
+    public void shouldBeActiveWhenAnAcceptedParameterAndValueArePresent() {
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("toggleFeatureX", (String[]) Arrays.asList("true").toArray());
+        parameters.put("toggleAll", (String[]) Arrays.asList("nope").toArray());
+        when(request.getParameterMap()).thenReturn(parameters);
 
-		boolean isActive = strategy.isActive(state, user);
+        boolean isActive = strategy.isActive(state, user);
 
-		Assert.assertTrue(isActive);
-	}
+        Assert.assertTrue(isActive);
+    }
 
-	@Test
-	public void shouldBeActiveWhenAnAcceptedParameterWithoutRequiredValueIsPresent(){
-		Map<String, String[]> parameters = new HashMap<>();
-		parameters.put("parameterWithoutValue", null);
-		when(request.getParameterMap()).thenReturn(parameters);
+    @Test
+    public void shouldBeActiveWhenAnAcceptedParameterWithoutRequiredValueIsPresent() {
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("parameterWithoutValue", null);
+        when(request.getParameterMap()).thenReturn(parameters);
 
-		boolean isActive = strategy.isActive(state, user);
+        boolean isActive = strategy.isActive(state, user);
 
-		Assert.assertTrue(isActive);
-	}
+        Assert.assertTrue(isActive);
+    }
 
-	@Test
-	public void shouldBeActiveWhenAnAcceptedParameterWithoutRequiredValueIsPresentAndItHasAValue(){
-		Map<String, String[]> parameters = new HashMap<>();
-		parameters.put("parameterWithoutValue", (String[]) Arrays.asList("anyVal").toArray());
-		when(request.getParameterMap()).thenReturn(parameters);
+    @Test
+    public void shouldBeActiveWhenAnAcceptedParameterWithoutRequiredValueIsPresentAndItHasAValue() {
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("parameterWithoutValue", (String[]) Arrays.asList("anyVal").toArray());
+        when(request.getParameterMap()).thenReturn(parameters);
 
-		boolean isActive = strategy.isActive(state, user);
+        boolean isActive = strategy.isActive(state, user);
 
-		Assert.assertTrue(isActive);
-	}
+        Assert.assertTrue(isActive);
+    }
 
-	@Test
-	public void shouldBeActiveRegardlessOfWhitespaceAroundActivationParams(){
-		Map<String, String[]> parameters = new HashMap<>();
-		parameters.put("parameterWithoutValue", null);
-		parameters.put("anotherParam", null);
-		when(request.getParameterMap()).thenReturn(parameters);
+    @Test
+    public void shouldBeActiveRegardlessOfWhitespaceAroundActivationParams() {
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("parameterWithoutValue", null);
+        parameters.put("anotherParam", null);
+        when(request.getParameterMap()).thenReturn(parameters);
 
-		state.setParameter(UrlParameterActivationStrategy.PARAM_URL_PARAMS, " toggleFeatureX  = true, toggleAll= yes, parameterWithoutValue ");
-		boolean isActive = strategy.isActive(state, user);
-		Assert.assertTrue(isActive);
-	}
+        state.setParameter(UrlParameterActivationStrategy.PARAM_URL_PARAMS,
+            " toggleFeatureX  = true, toggleAll= yes, parameterWithoutValue ");
+        boolean isActive = strategy.isActive(state, user);
+        Assert.assertTrue(isActive);
+    }
 
-	@Test
-	public void shouldBeActiveIfParameterWithMultipleValuesHasAnyMatch(){
-		Map<String, String[]> parameters = new HashMap<>();
-		parameters.put("parameterWithoutValue", null);
-		parameters.put("anotherParam", null);
-		when(request.getParameterMap()).thenReturn(parameters);
+    @Test
+    public void shouldBeActiveIfParameterWithMultipleValuesHasAnyMatch() {
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("parameterWithoutValue", null);
+        parameters.put("anotherParam", null);
+        when(request.getParameterMap()).thenReturn(parameters);
 
-		parameters.put("test",  (String[]) Arrays.asList("matches", "nomatch", "notanything").toArray());
-		state.setParameter(UrlParameterActivationStrategy.PARAM_URL_PARAMS, "test=matches");
+        parameters.put("test", (String[]) Arrays.asList("matches", "nomatch", "notanything").toArray());
+        state.setParameter(UrlParameterActivationStrategy.PARAM_URL_PARAMS, "test=matches");
 
-		boolean isActive = strategy.isActive(state, user);
+        boolean isActive = strategy.isActive(state, user);
 
-		Assert.assertTrue(isActive);
-	}
+        Assert.assertTrue(isActive);
+    }
 
-	@Test
-	public void strategyShouldCheckParametersOfReferrer(){
-		Map<String, String[]> parameters = new HashMap<>();
-		when(request.getParameterMap()).thenReturn(parameters);
+    @Test
+    public void strategyShouldCheckParametersOfReferrer() {
+        Map<String, String[]> parameters = new HashMap<>();
+        when(request.getParameterMap()).thenReturn(parameters);
 
-		when(request.getHeader("referer")).thenReturn("http://mysite.com/?parameterWithoutValue");
-		boolean isActive = strategy.isActive(state, user);
-		Assert.assertTrue(isActive);
+        when(request.getHeader("referer")).thenReturn("http://mysite.com/?parameterWithoutValue");
+        boolean isActive = strategy.isActive(state, user);
+        Assert.assertTrue(isActive);
 
-		when(request.getHeader("referer")).thenReturn("http://mysite.com/?someOtherParameter");
-		isActive = strategy.isActive(state, user);
-		Assert.assertFalse(isActive);
+        when(request.getHeader("referer")).thenReturn("http://mysite.com/?someOtherParameter");
+        isActive = strategy.isActive(state, user);
+        Assert.assertFalse(isActive);
 
-		when(request.getHeader("referer")).thenReturn("http://mysite.com/?toggleFeatureX=true");
-		isActive = strategy.isActive(state, user);
-		Assert.assertTrue(isActive);
-	}
+        when(request.getHeader("referer")).thenReturn("http://mysite.com/?toggleFeatureX=true");
+        isActive = strategy.isActive(state, user);
+        Assert.assertTrue(isActive);
+    }
 
-	@Test
-	public void refererParamsShouldNotOverrideRequestParamsButWillQualifyAsActiveIfSeparate(){
-		Map<String, String[]> parameters = new HashMap<>();
-		parameters.put("toggleFeatureX", (String[]) Arrays.asList("false").toArray());
-		when(request.getParameterMap()).thenReturn(parameters);
+    @Test
+    public void refererParamsShouldNotOverrideRequestParamsButWillQualifyAsActiveIfSeparate() {
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("toggleFeatureX", (String[]) Arrays.asList("false").toArray());
+        when(request.getParameterMap()).thenReturn(parameters);
 
-		when(request.getHeader("referer")).thenReturn("http://mysite.com/?toggleFeatureX=true");
-		boolean isActive = strategy.isActive(state, user);
-		Assert.assertFalse(isActive);
+        when(request.getHeader("referer")).thenReturn("http://mysite.com/?toggleFeatureX=true");
+        boolean isActive = strategy.isActive(state, user);
+        Assert.assertFalse(isActive);
 
-		when(request.getHeader("referer")).thenReturn("http://mysite.com/?parameterWithoutValue");
-		isActive = strategy.isActive(state, user);
-		Assert.assertTrue(isActive);
-	}
+        when(request.getHeader("referer")).thenReturn("http://mysite.com/?parameterWithoutValue");
+        isActive = strategy.isActive(state, user);
+        Assert.assertTrue(isActive);
+    }
 
-	@Test
-	public void refererWithMultiValueParamsShouldBeChecked(){
-		Map<String, String[]> parameters = new HashMap<>();
-		when(request.getParameterMap()).thenReturn(parameters);
+    @Test
+    public void refererWithMultiValueParamsShouldBeChecked() {
+        Map<String, String[]> parameters = new HashMap<>();
+        when(request.getParameterMap()).thenReturn(parameters);
 
-		when(request.getHeader("referer")).thenReturn("http://mysite.com/?toggleFeatureX=false&toggleFeatureX=nope&toggleFeatureX=true");
-		boolean isActive = strategy.isActive(state, user);
-		Assert.assertTrue(isActive);
-	}
+        when(request.getHeader("referer"))
+            .thenReturn("http://mysite.com/?toggleFeatureX=false&toggleFeatureX=nope&toggleFeatureX=true");
+        boolean isActive = strategy.isActive(state, user);
+        Assert.assertTrue(isActive);
+    }
+
+    @Test
+    public void refererWithEncodedParamsCanMatch() {
+        Map<String, String[]> parameters = new HashMap<>();
+        when(request.getParameterMap()).thenReturn(parameters);
+        state.setParameter(UrlParameterActivationStrategy.PARAM_URL_PARAMS,
+            "toggleFeatureX=handles space,toggleAll=yes,parameterWithoutValue");
+
+        when(request.getHeader("referer"))
+            .thenReturn("http://mysite.com/?toggleFeatureX=handles%20space&toggleFeatureX=a%22thing");
+        boolean isActive = strategy.isActive(state, user);
+        Assert.assertTrue(isActive);
+    }
 }

--- a/servlet/src/test/java/org/togglz/servlet/activation/UrlParameterActivationStrategyTest.java
+++ b/servlet/src/test/java/org/togglz/servlet/activation/UrlParameterActivationStrategyTest.java
@@ -27,7 +27,7 @@ public class UrlParameterActivationStrategyTest {
 	private final UrlParameterActivationStrategy strategy = new UrlParameterActivationStrategy();
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		user = new SimpleFeatureUser("ea", false);
 		state = new FeatureState(MyFeature.FEATURE).enable();
 		state.setParameter(UrlParameterActivationStrategy.PARAM_URL_PARAMS, "toggleFeatureX=true,toggleAll=yes,parameterWithoutValue");

--- a/servlet/src/test/java/org/togglz/servlet/activation/UrlParameterActivationStrategyTest.java
+++ b/servlet/src/test/java/org/togglz/servlet/activation/UrlParameterActivationStrategyTest.java
@@ -1,0 +1,203 @@
+package org.togglz.servlet.activation;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.togglz.core.Feature;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.user.FeatureUser;
+import org.togglz.core.user.SimpleFeatureUser;
+import org.togglz.servlet.util.HttpServletRequestHolder;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+
+public class UrlParameterActivationStrategyTest {
+	private FeatureUser user;
+	private FeatureState state;
+	private HttpServletRequest request;
+	private final UrlParameterActivationStrategy strategy = new UrlParameterActivationStrategy();
+
+	@Before
+	public void setup() {
+		user = new SimpleFeatureUser("ea", false);
+		state = new FeatureState(MyFeature.FEATURE).enable();
+		state.setParameter(UrlParameterActivationStrategy.PARAM_URL_PARAMS, "toggleFeatureX=true,toggleAll=yes,parameterWithoutValue");
+		request = Mockito.mock(HttpServletRequest.class);
+		HttpServletRequestHolder.bind(request);
+	}
+
+	@After
+	public void cleanup(){
+		HttpServletRequestHolder.release();
+	}
+
+	private enum MyFeature implements Feature {
+		FEATURE
+	}
+
+	@Test
+	public void shouldNotBeActiveWithANullRequestObject(){
+		HttpServletRequestHolder.release();
+
+		boolean isActive = strategy.isActive(state, user);
+
+		Assert.assertFalse(isActive);
+	}
+
+	@Test
+	public void shouldNotBeActiveWithNoPermittedParameters(){
+		when(request.getParameterMap()).thenReturn(Collections.EMPTY_MAP);
+
+		boolean isActive = strategy.isActive(state, user);
+
+		Assert.assertFalse(isActive);
+	}
+
+	@Test
+	public void shouldNotBeActiveWhenOnlyNonMatchingParametersArePresent(){
+		Map<String, String[]> parameters = new HashMap<>();
+		parameters.put("somethingThatDoesNotMatch", (String[]) Arrays.asList("true").toArray());
+		parameters.put("somethingElse", (String[]) Arrays.asList("aValue").toArray());
+		when(request.getParameterMap()).thenReturn(parameters);
+
+		boolean isActive = strategy.isActive(state, user);
+
+		Assert.assertFalse(isActive);
+	}
+
+	@Test
+	public void shouldNotBeActiveWhenMatchingParameterHasANonMatchingValue(){
+		Map<String, String[]> parameters = new HashMap<>();
+		parameters.put("toggleFeatureX", (String[]) Arrays.asList("false").toArray());
+		parameters.put("toggleAll", (String[]) Arrays.asList("nope").toArray());
+		when(request.getParameterMap()).thenReturn(parameters);
+
+		boolean isActive = strategy.isActive(state, user);
+
+		Assert.assertFalse(isActive);
+	}
+
+	@Test
+	public void shouldNotBeActiveWhenMatchingParameterRequiringValueDoesNotHaveValue(){
+		Map<String, String[]> parameters = new HashMap<>();
+		parameters.put("toggleFeatureX", null);
+		when(request.getParameterMap()).thenReturn(parameters);
+
+		boolean isActive = strategy.isActive(state, user);
+
+		Assert.assertFalse(isActive);
+	}
+
+	@Test
+	public void shouldBeActiveWhenAnAcceptedParameterAndValueArePresent(){
+		Map<String, String[]> parameters = new HashMap<>();
+		parameters.put("toggleFeatureX", (String[]) Arrays.asList("true").toArray());
+		parameters.put("toggleAll", (String[]) Arrays.asList("nope").toArray());
+		when(request.getParameterMap()).thenReturn(parameters);
+
+		boolean isActive = strategy.isActive(state, user);
+
+		Assert.assertTrue(isActive);
+	}
+
+	@Test
+	public void shouldBeActiveWhenAnAcceptedParameterWithoutRequiredValueIsPresent(){
+		Map<String, String[]> parameters = new HashMap<>();
+		parameters.put("parameterWithoutValue", null);
+		when(request.getParameterMap()).thenReturn(parameters);
+
+		boolean isActive = strategy.isActive(state, user);
+
+		Assert.assertTrue(isActive);
+	}
+
+	@Test
+	public void shouldBeActiveWhenAnAcceptedParameterWithoutRequiredValueIsPresentAndItHasAValue(){
+		Map<String, String[]> parameters = new HashMap<>();
+		parameters.put("parameterWithoutValue", (String[]) Arrays.asList("anyVal").toArray());
+		when(request.getParameterMap()).thenReturn(parameters);
+
+		boolean isActive = strategy.isActive(state, user);
+
+		Assert.assertTrue(isActive);
+	}
+
+	@Test
+	public void shouldBeActiveRegardlessOfWhitespaceAroundActivationParams(){
+		Map<String, String[]> parameters = new HashMap<>();
+		parameters.put("parameterWithoutValue", null);
+		parameters.put("anotherParam", null);
+		when(request.getParameterMap()).thenReturn(parameters);
+
+		state.setParameter(UrlParameterActivationStrategy.PARAM_URL_PARAMS, " toggleFeatureX  = true, toggleAll= yes, parameterWithoutValue ");
+		boolean isActive = strategy.isActive(state, user);
+		Assert.assertTrue(isActive);
+	}
+
+	@Test
+	public void shouldBeActiveIfParameterWithMultipleValuesHasAnyMatch(){
+		Map<String, String[]> parameters = new HashMap<>();
+		parameters.put("parameterWithoutValue", null);
+		parameters.put("anotherParam", null);
+		when(request.getParameterMap()).thenReturn(parameters);
+
+		parameters.put("test",  (String[]) Arrays.asList("matches", "nomatch", "notanything").toArray());
+		state.setParameter(UrlParameterActivationStrategy.PARAM_URL_PARAMS, "test=matches");
+
+		boolean isActive = strategy.isActive(state, user);
+
+		Assert.assertTrue(isActive);
+	}
+
+	@Test
+	public void strategyShouldCheckParametersOfReferrer(){
+		Map<String, String[]> parameters = new HashMap<>();
+		when(request.getParameterMap()).thenReturn(parameters);
+
+		when(request.getHeader("referer")).thenReturn("http://mysite.com/?parameterWithoutValue");
+		boolean isActive = strategy.isActive(state, user);
+		Assert.assertTrue(isActive);
+
+		when(request.getHeader("referer")).thenReturn("http://mysite.com/?someOtherParameter");
+		isActive = strategy.isActive(state, user);
+		Assert.assertFalse(isActive);
+
+		when(request.getHeader("referer")).thenReturn("http://mysite.com/?toggleFeatureX=true");
+		isActive = strategy.isActive(state, user);
+		Assert.assertTrue(isActive);
+	}
+
+	@Test
+	public void refererParamsShouldNotOverrideRequestParamsButWillQualifyAsActiveIfSeparate(){
+		Map<String, String[]> parameters = new HashMap<>();
+		parameters.put("toggleFeatureX", (String[]) Arrays.asList("false").toArray());
+		when(request.getParameterMap()).thenReturn(parameters);
+
+		when(request.getHeader("referer")).thenReturn("http://mysite.com/?toggleFeatureX=true");
+		boolean isActive = strategy.isActive(state, user);
+		Assert.assertFalse(isActive);
+
+		when(request.getHeader("referer")).thenReturn("http://mysite.com/?parameterWithoutValue");
+		isActive = strategy.isActive(state, user);
+		Assert.assertTrue(isActive);
+	}
+
+	@Test
+	public void refererWithMultiValueParamsShouldBeChecked(){
+		Map<String, String[]> parameters = new HashMap<>();
+		when(request.getParameterMap()).thenReturn(parameters);
+
+		when(request.getHeader("referer")).thenReturn("http://mysite.com/?toggleFeatureX=false&toggleFeatureX=nope&toggleFeatureX=true");
+		boolean isActive = strategy.isActive(state, user);
+		Assert.assertTrue(isActive);
+	}
+}

--- a/servlet/template.mf
+++ b/servlet/template.mf
@@ -8,5 +8,5 @@ Version-Patterns:
  default;pattern="[=.=.=, =.+1.0)"
 Import-Template:
  javax.servlet.*;version="0",
- org.togglz.core.*;version="${osgi.bundles.version:default}"
+ org.togglz.core.*;version="${osgi.bundles.version:default}",
  org.apache.httpcomponents.*;version="4.5.2"

--- a/servlet/template.mf
+++ b/servlet/template.mf
@@ -8,5 +8,4 @@ Version-Patterns:
  default;pattern="[=.=.=, =.+1.0)"
 Import-Template:
  javax.servlet.*;version="0",
- org.togglz.core.*;version="${osgi.bundles.version:default}",
- org.apache.*;version="4.5.2"
+ org.togglz.core.*;version="${osgi.bundles.version:default}"

--- a/servlet/template.mf
+++ b/servlet/template.mf
@@ -9,4 +9,4 @@ Version-Patterns:
 Import-Template:
  javax.servlet.*;version="0",
  org.togglz.core.*;version="${osgi.bundles.version:default}",
- org.apache.httpcomponents.*;version="4.5.2"
+ org.apache.*;version="4.5.2"

--- a/servlet/template.mf
+++ b/servlet/template.mf
@@ -9,3 +9,4 @@ Version-Patterns:
 Import-Template:
  javax.servlet.*;version="0",
  org.togglz.core.*;version="${osgi.bundles.version:default}"
+ org.apache.httpcomponents.*;version="4.5.2"


### PR DESCRIPTION
My team has found this activation strategy very useful for developing and testing incomplete features that are being released dark. The ability to quickly view the toggled feature in an on/off state has proved valuable during development and when sharing links with stakeholders. URL parameters are a simple mechanism and enable stakeholders to keep up with progress while end users still do not have the toggled feature. 

Since this project has been incredibly valuable to us, I wanted to contribute this activation strategy back to the core project. Thank you!