### PR TITLE
Utilize openjdk7 instead of oraclejdk7 for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 after_success:
   - "bash .travis-sonatype-deploy.sh"
 jdk:
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
 notifications:
   webhooks:
@@ -24,4 +24,3 @@ env:
     - CONTAINER=wildfly-managed
     - secure: "OnYfX1bWd1nt4lU6fGEtiWc/AqNwac32YQEm8AdPaU83zOZGe2yyBOLX+fTxqp7CUPpbJM0kLCQzDTrurwXJNtd9D8b8C5rWBvvNS7tloVlwCMbfSiSXpJZK6bygGo0puQcnFtaivtmGD6DRZQWgbVKNdJf5iW/X+46k+nOZqtg="
     - secure: "mjX857IwiXKts1ZWrKDVQOQpkFN+vUrPmQNneYim4dVN+McXOiyyvM/iYgH14E2FFHlWe/1fHLU59Wf34r7K7T+cd8J79D78u6dIljHmxucMu5+O7giexzkvEqTXafAQQrLSan0iUnU3dgcYbqaZ9Fz5ZRjC7gLF48mRUsf+lIc="
-


### PR DESCRIPTION
Due to the withdrawal of oraclejdk7 in Ubuntu trusty, no Oracle JDK 7 builds can be performed anymore. 
See https://github.com/travis-ci/travis-ci/issues/7884 for more details.

`openjdk7` can still be used for JDK7 builds.