### PR TITLE
Adding support for a MicroProfile Config based property activation strategy.

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -178,5 +178,16 @@
     </dependency>
 
   </dependencies>
-
+  <profiles>
+    <profile>
+      <id>java8-features</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.togglz</groupId>
+          <artifactId>togglz-microprofile-config</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -54,6 +54,7 @@
         <include>org.togglz:togglz-amazon-s3:jar:*</include>
         <include>org.togglz:togglz-slack:jar:*</include>
         <include>org.togglz:togglz-redis:jar:*</include>
+        <include>org.togglz:togglz-microprofile-config:jar:*</include>
       </includes>
     </dependencySet>
 

--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.togglz</groupId>
+        <artifactId>togglz-project</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>togglz-microprofile-config</artifactId>
+    <name>Togglz - MicroProfile Config integration</name>
+    <description>Togglz - MicroProfile Config integration</description>
+
+    <properties>
+        <microprofile.config.version>1.1</microprofile.config.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.togglz</groupId>
+            <artifactId>togglz-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <version>${microprofile.config.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.geronimo.config</groupId>
+            <artifactId>geronimo-config-impl</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/microprofile-config/src/main/java/org/togglz/microprofile/activation/MicroProfileConfigActivationStrategy.java
+++ b/microprofile-config/src/main/java/org/togglz/microprofile/activation/MicroProfileConfigActivationStrategy.java
@@ -1,0 +1,41 @@
+package org.togglz.microprofile.activation;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.togglz.core.Feature;
+import org.togglz.core.activation.AbstractPropertyDrivenActivationStrategy;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.user.FeatureUser;
+
+/**
+ * <p>
+ * An activation strategy based on the values of properties accessible within the MicroProfile Config.
+ * </p>
+ * <p>
+ * It can either be based on a given property name, passed via the "{@value #PARAM_NAME}" parameter, or a property name
+ * derived from the {@link Feature} itself (e.g. "{@value #DEFAULT_PROPERTY_PREFIX}FEATURE_NAME").
+ * </p>
+ *
+ * @author John D. Ament, based on work in DeltaSpikePropertyActivationStrategy from Alasdair Mercer
+ * @see AbstractPropertyDrivenActivationStrategy
+ */
+public class MicroProfileConfigActivationStrategy extends AbstractPropertyDrivenActivationStrategy {
+
+    public static final String ID = "microprofile-config-property";
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public String getName() {
+        return "MicroProfile Config Property";
+    }
+
+    @Override
+    protected String getPropertyValue(FeatureState featureState, FeatureUser user, String name) {
+        Config config = ConfigProvider.getConfig();
+        return config.getOptionalValue(name, String.class).orElse(null);
+    }
+}

--- a/microprofile-config/src/main/resources/META-INF/services/org.togglz.core.spi.ActivationStrategy
+++ b/microprofile-config/src/main/resources/META-INF/services/org.togglz.core.spi.ActivationStrategy
@@ -1,0 +1,1 @@
+org.togglz.microprofile.activation.MicroProfileConfigActivationStrategy

--- a/microprofile-config/src/test/java/org/togglz/microprofile/TestConfigSourceProvider.java
+++ b/microprofile-config/src/test/java/org/togglz/microprofile/TestConfigSourceProvider.java
@@ -1,0 +1,46 @@
+package org.togglz.microprofile;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.singleton;
+
+/**
+ * A test config source provider for MicroProfile Config
+ */
+public class TestConfigSourceProvider implements ConfigSourceProvider{
+    @Override
+    public Iterable<ConfigSource> getConfigSources(ClassLoader classLoader) {
+        return singleton(TestConfigSource.INSTANCE);
+    }
+
+    public static class TestConfigSource implements ConfigSource {
+        public static TestConfigSource INSTANCE = new TestConfigSource();
+        private Map<String, String> properties = new HashMap<>();
+        @Override
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+
+        @Override
+        public String getValue(String name) {
+            return properties.get(name);
+        }
+
+        @Override
+        public String getName() {
+            return "microprofile-config-test-source";
+        }
+
+        public void clearProperties() {
+            properties.clear();
+        }
+
+        public void putProperty(String key, String value) {
+            properties.put(key,value);
+        }
+    }
+}

--- a/microprofile-config/src/test/java/org/togglz/microprofile/activation/MicroProfileConfigActivationStrategyTest.java
+++ b/microprofile-config/src/test/java/org/togglz/microprofile/activation/MicroProfileConfigActivationStrategyTest.java
@@ -1,0 +1,94 @@
+package org.togglz.microprofile.activation;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+import org.togglz.core.Feature;
+import org.togglz.core.activation.Parameter;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.util.Strings;
+import org.togglz.microprofile.TestConfigSourceProvider;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * <p>
+ * Tests for the {@link MicroProfileConfigActivationStrategy} class.
+ * </p>
+ *
+ * @author John D. Ament, Alasdair Mercer
+ */
+@RunWith(Theories.class)
+public class MicroProfileConfigActivationStrategyTest {
+
+    @DataPoints
+    public static final boolean[] DATA_POINTS = { true, false };
+
+    private MicroProfileConfigActivationStrategy strategy;
+
+    @Before
+    public void setUp() {
+        strategy = new MicroProfileConfigActivationStrategy();
+    }
+
+    @After
+    public void tearDown() {
+        TestConfigSourceProvider.TestConfigSource.INSTANCE.clearProperties();
+    }
+
+    @Test
+    public void testGetId() {
+        assertEquals(MicroProfileConfigActivationStrategy.ID, strategy.getId());
+    }
+
+    @Test
+    public void testGetName() {
+        assertTrue(Strings.isNotBlank(strategy.getName()));
+    }
+
+    @Theory
+    public void testIsActiveWithNoParam(boolean enabled) {
+        FeatureState featureState = new FeatureState(TestFeatures.FEATURE_ONE, !enabled);
+
+        TestConfigSourceProvider.TestConfigSource.INSTANCE.putProperty("togglz.FEATURE_ONE", String.valueOf(enabled));
+
+        assertEquals(enabled, strategy.isActive(featureState, null));
+    }
+
+    @Theory
+    public void testIsActiveWithParam(boolean enabled) {
+        String paramValue = "foo";
+        FeatureState featureState = new FeatureState(TestFeatures.FEATURE_ONE, !enabled);
+        featureState.setParameter(MicroProfileConfigActivationStrategy.PARAM_NAME, paramValue);
+
+        TestConfigSourceProvider.TestConfigSource.INSTANCE.putProperty(paramValue, String.valueOf(enabled));
+
+        assertEquals(enabled, strategy.isActive(featureState, null));
+    }
+
+    @Test
+    public void testGetParameters() {
+        Parameter[] parameters = strategy.getParameters();
+
+        assertEquals(1, parameters.length);
+
+        Parameter parameter = parameters[0];
+
+        assertNotNull(parameter);
+        assertEquals(MicroProfileConfigActivationStrategy.PARAM_NAME, parameter.getName());
+        assertTrue(parameter.isOptional());
+        assertTrue(Strings.isNotBlank(parameter.getLabel()));
+        assertTrue(Strings.isNotBlank(parameter.getDescription()));
+    }
+
+    public enum TestFeatures implements Feature {
+
+        FEATURE_ONE
+    }
+}

--- a/microprofile-config/src/test/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSourceProvider
+++ b/microprofile-config/src/test/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSourceProvider
@@ -1,0 +1,1 @@
+org.togglz.microprofile.TestConfigSourceProvider

--- a/microprofile-config/template.mf
+++ b/microprofile-config/template.mf
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: org.togglz.deltaspike
+Bundle-Vendor: http://www.togglz.org/
+Bundle-Version: ${osgi.bundles.version}
+Bundle-Name: ${project.name}
+Version-Patterns:
+ default;pattern="[=.=.=, =.+1.0)"
+Import-Template:
+ org.togglz.core.*;version="${osgi.bundles.version:default}",
+ org.eclipse.microprofile.config.*;version="0"

--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,16 @@
       </properties>
     </profile>
 
+    <profile>
+      <id>java8-features</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <modules>
+        <module>microprofile-config</module>
+      </modules>
+    </profile>
+
   </profiles>
 
   <dependencyManagement>


### PR DESCRIPTION
Most of this is based on the existing abstraction of a property based look up, but against the MicroProfile Config API.