### PR TITLE
Add JUnit 5 Extensions

### DIFF
--- a/junit/src/main/java/org/togglz/junit/TogglzRule.java
+++ b/junit/src/main/java/org/togglz/junit/TogglzRule.java
@@ -11,9 +11,9 @@ import org.togglz.core.logging.Log;
 import org.togglz.core.logging.LogFactory;
 import org.togglz.core.util.NamedFeature;
 import org.togglz.core.util.Validate;
-import org.togglz.junit.vary.VariationSetBuilder;
 import org.togglz.testing.TestFeatureManager;
 import org.togglz.testing.TestFeatureManagerProvider;
+import org.togglz.testing.vary.VariationSetBuilder;
 
 /**
  * <p>

--- a/junit/src/main/java/org/togglz/junit/vary/FeatureVariations.java
+++ b/junit/src/main/java/org/togglz/junit/vary/FeatureVariations.java
@@ -12,6 +12,7 @@ import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.TestClass;
 import org.togglz.core.Feature;
+import org.togglz.testing.vary.VariationSet;
 
 /**
  * <p>
@@ -63,7 +64,7 @@ public class FeatureVariations extends Suite {
 
         TestClass testClass = new TestClass(clazz);
 
-        VariationSetBuilder<? extends Feature> permutation = getPermutationFromMethod(testClass);
+        VariationSet<? extends Feature> permutation = getPermutationFromMethod(testClass);
         if (permutation == null) {
             throw new IllegalStateException("You have to place a @" + Variations.class.getSimpleName()
                     + " annotation one the class: " + clazz.getName());
@@ -75,14 +76,14 @@ public class FeatureVariations extends Suite {
 
     }
 
-    private VariationSetBuilder<? extends Feature> getPermutationFromMethod(TestClass testClass) {
+    private VariationSet<? extends Feature> getPermutationFromMethod(TestClass testClass) {
 
         List<FrameworkMethod> methods = testClass.getAnnotatedMethods(Variations.class);
         for (FrameworkMethod method : methods) {
             int modifiers = method.getMethod().getModifiers();
             if (Modifier.isStatic(modifiers) && Modifier.isPublic(modifiers)) {
                 try {
-                    return (VariationSetBuilder) method.invokeExplosively(null);
+                    return (VariationSet) method.invokeExplosively(null);
                 } catch (Throwable e) {
                     throw new IllegalStateException(e);
                 }

--- a/junit/src/main/java/org/togglz/junit/vary/VariationSet.java
+++ b/junit/src/main/java/org/togglz/junit/vary/VariationSet.java
@@ -1,25 +1,13 @@
 package org.togglz.junit.vary;
 
-import java.util.Set;
-
 import org.togglz.core.Feature;
 
 /**
- * This class represents a set of feature state variants. It is used to configure unit test that are executed with
- * {@link FeatureVariations}. The common implementation of this interface is {@link VariationSetBuilder} which allows to build
- * sets dynamically.
- * 
- * @author Christian Kaltepoth
- * 
- * @see FeatureVariations
- * @see VariationSetBuilder
+ * @see org.togglz.testing.vary.VariationSet
  * @param <F> The feature class
+ *
+ * @deprecated use {@link org.togglz.testing.vary.VariationSet} instead
  */
-public interface VariationSet<F extends Feature> {
-
-    /**
-     * Build the variant set data structure from the current configuration of the class.
-     */
-    Set<Set<F>> getVariants();
-
+@Deprecated
+public interface VariationSet<F extends Feature> extends org.togglz.testing.vary.VariationSet<F> {
 }

--- a/junit/src/main/java/org/togglz/junit/vary/VariationSetBuilder.java
+++ b/junit/src/main/java/org/togglz/junit/vary/VariationSetBuilder.java
@@ -1,148 +1,55 @@
 package org.togglz.junit.vary;
 
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
-
 import org.togglz.core.Feature;
-import org.togglz.core.util.Validate;
 
 /**
- * Default implementation of {@link VariationSet} that allows to build the set dynamically.
- * 
- * @author Christian Kaltepoth
- * 
+ * @see org.togglz.testing.vary.VariationSetBuilder
  * @param <F> The feature class
+ *
+ * @deprecated use {@link org.togglz.testing.vary.VariationSetBuilder} instead
  */
-public class VariationSetBuilder<F extends Feature> implements VariationSet<F>
-{
+@Deprecated
+public class VariationSetBuilder<F extends Feature> extends org.togglz.testing.vary.VariationSetBuilder<F>
+    implements VariationSet<F> {
 
-    public static <F extends Feature> VariationSetBuilder<F> create(Class<F> featureClass)
-    {
+    /**
+     * @deprecated use {@link org.togglz.testing.vary.VariationSetBuilder#create(Class)} instead
+     */
+    public static <F extends Feature> VariationSetBuilder<F> create(Class<F> featureClass) {
         return new VariationSetBuilder<F>(featureClass);
     }
 
-    private final Class<F> featureClass;
-
-    private final Set<F> featuresToVary = new HashSet<F>();
-    private final Set<F> featuresToEnable = new HashSet<F>();
-    private final Set<F> featuresToDisable = new HashSet<F>();
-
-    private VariationSetBuilder(Class<F> featureEnum)
-    {
-        Validate.notNull(featureEnum, "The featureEnum argument is required");
-        Validate.isTrue(featureEnum.isEnum(), "This class only works with feature enums");
-        this.featureClass = featureEnum;
+    private VariationSetBuilder(Class<F> featureEnum) {
+        super(featureEnum);
     }
 
-    /**
-     * Vary this feature in the variation set.
-     */
-    public VariationSetBuilder<F> vary(F f)
-    {
-        featuresToVary.add(f);
-        featuresToEnable.remove(f);
-        featuresToDisable.remove(f);
-        return this;
-    }
-
-    /**
-     * Enable this feature in the variation set.
-     */
-    public VariationSetBuilder<F> enable(F f)
-    {
-        featuresToVary.remove(f);
-        featuresToEnable.add(f);
-        featuresToDisable.remove(f);
-        return this;
-    }
-
-    /**
-     * Disable this feature in the variation set.
-     */
-    public VariationSetBuilder<F> disable(F f)
-    {
-        featuresToVary.remove(f);
-        featuresToEnable.remove(f);
-        featuresToDisable.add(f);
-        return this;
-    }
-
-    /**
-     * Enable all features in the variation set.
-     */
-    public VariationSetBuilder<F> enableAll() {
-        for (F f : featureClass.getEnumConstants()) {
-            enable(f);
-        }
-        return this;
-    }
-
-    /**
-     * Disable all features in the variation set.
-     */
-    public VariationSetBuilder<F> disableAll() {
-        for (F f : featureClass.getEnumConstants()) {
-            disable(f);
-        }
-        return this;
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.togglz.junit.vary.VariationSet#getVariants()
-     */
     @Override
-    public Set<Set<F>> getVariants()
-    {
-
-        // start with a single variant with all feature disabled
-        Set<Set<F>> variantSet = new LinkedHashSet<Set<F>>();
-        variantSet.add(new HashSet<F>());
-
-        for (F feature : featureClass.getEnumConstants()) {
-
-            // enable the feature in all variants
-            if (featuresToEnable.contains(feature)) {
-                for (Set<F> variant : variantSet) {
-                    variant.add(feature);
-                }
-            }
-
-            // disable the feature in all variants
-            else if (featuresToDisable.contains(feature)) {
-                for (Set<F> variant : variantSet) {
-                    variant.remove(feature);
-                }
-            }
-
-            // copy the existing variants, enable the feature in the copy, and merge them
-            else if (featuresToVary.contains(feature)) {
-                Set<Set<F>> copy = deepCopy(variantSet);
-                for (Set<F> variant : copy) {
-                    variant.add(feature);
-                }
-                variantSet.addAll(copy);
-            }
-
-        }
-
-        return variantSet;
-
+    public VariationSetBuilder<F> vary(F f) {
+        super.vary(f);
+        return this;
     }
 
-    private Set<Set<F>> deepCopy(Set<Set<F>> src) {
-        Set<Set<F>> copy = new LinkedHashSet<Set<F>>();
-        for (Set<F> variant : src) {
-            copy.add(new HashSet<F>(variant));
-        }
-        return copy;
+    @Override
+    public VariationSetBuilder<F> enable(F f) {
+        super.enable(f);
+        return this;
     }
 
-    public Class<? extends Feature> getFeatureClass()
-    {
-        return featureClass;
+    @Override
+    public VariationSetBuilder<F> disable(F f) {
+        super.disable(f);
+        return this;
     }
 
+    @Override
+    public VariationSetBuilder<F> enableAll() {
+        super.enableAll();
+        return this;
+    }
+
+    @Override
+    public VariationSetBuilder<F> disableAll() {
+        super.disableAll();
+        return this;
+    }
 }

--- a/junit/src/main/java/org/togglz/junit/vary/Variations.java
+++ b/junit/src/main/java/org/togglz/junit/vary/Variations.java
@@ -4,6 +4,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.togglz.testing.vary.VariationSetBuilder;
 
 /**
  * This annotation is used if a test class is executed with {@link FeatureVariations}. The method annotated with this annotation

--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.togglz</groupId>
+    <artifactId>togglz-project</artifactId>
+    <version>2.6.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>togglz-junit5</artifactId>
+  <name>Togglz - JUnit 5 integration</name>
+  <description>Togglz - JUnit 5 integration</description>
+
+  <properties>
+    <!-- Minimal Java version -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+
+    <junit.jupiter.version>5.0.0</junit.jupiter.version>
+    <junit.platform.version>1.0.0</junit.platform.version>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.togglz</groupId>
+      <artifactId>togglz-testing</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <useDefaultManifestFile>true</useDefaultManifestFile>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.virgo.bundlor</groupId>
+        <artifactId>org.eclipse.virgo.bundlor.maven</artifactId>
+        <executions>
+          <execution>
+            <id>bundlor</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-surefire-provider</artifactId>
+            <version>${junit.platform.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/junit5/src/main/java/org/togglz/junit5/AllDisabled.java
+++ b/junit5/src/main/java/org/togglz/junit5/AllDisabled.java
@@ -1,0 +1,48 @@
+package org.togglz.junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.togglz.core.Feature;
+
+/**
+ * <p>
+ *     Creates a {@link org.togglz.testing.TestFeatureManager TestFeatureManager} with all features disabled.
+ * </p>
+ *
+ * <p>
+ *     To enable single features the {@link org.togglz.testing.TestFeatureManager TestFeatureManager}
+ *     is available as parameter.
+ * </p>
+ *
+ * <p>
+ *     Example Usage:
+ * </p>
+ * <pre>
+ *     class MyTest {
+ *
+ *         &#064;Test
+ *         &#064;AllDisabled(MyFeatures.class)
+ *         void run(TestFeatureManager featureManager) {
+ *             assertFalse(featureManager.isActive(MyFeatures.ONE));
+ *
+ *             featureManager.enable(MyFeatures.ONE);
+ *             assertTrue(featureManager.isActive(MyFeatures.ONE));
+ *         }
+ *     }
+ * </pre>
+ *
+ * @see AllEnabled
+ *
+ * @author Roland Weisleder
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@ExtendWith(AnnotationBasedTogglzExtension.class)
+public @interface AllDisabled {
+
+    Class<? extends Feature> value();
+
+}

--- a/junit5/src/main/java/org/togglz/junit5/AllEnabled.java
+++ b/junit5/src/main/java/org/togglz/junit5/AllEnabled.java
@@ -1,0 +1,48 @@
+package org.togglz.junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.togglz.core.Feature;
+
+/**
+ * <p>
+ *     Creates a {@link org.togglz.testing.TestFeatureManager TestFeatureManager} with all features enabled.
+ * </p>
+ *
+ * <p>
+ *     To disable single features the {@link org.togglz.testing.TestFeatureManager TestFeatureManager}
+ *     is available as parameter.
+ * </p>
+ *
+ * <p>
+ *     Example Usage:
+ * </p>
+ * <pre>
+ *     class MyTest {
+ *
+ *         &#064;Test
+ *         &#064;AllEnabled(MyFeatures.class)
+ *         void run(TestFeatureManager featureManager) {
+ *             assertTrue(featureManager.isActive(MyFeatures.ONE));
+ *
+ *             featureManager.disable(MyFeatures.ONE);
+ *             assertFalse(featureManager.isActive(MyFeatures.ONE));
+ *         }
+ *     }
+ * </pre>
+ *
+ * @see AllDisabled
+ *
+ * @author Roland Weisleder
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@ExtendWith(AnnotationBasedTogglzExtension.class)
+public @interface AllEnabled {
+
+    Class<? extends Feature> value();
+
+}

--- a/junit5/src/main/java/org/togglz/junit5/AnnotationBasedTogglzExtension.java
+++ b/junit5/src/main/java/org/togglz/junit5/AnnotationBasedTogglzExtension.java
@@ -1,0 +1,51 @@
+package org.togglz.junit5;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.togglz.testing.TestFeatureManager;
+
+/**
+ * <p>
+ *     JUnit Extension, which creates a {@link TestFeatureManager} with all features enabled/disabled.
+ * </p>
+ *
+ * @see AllEnabled
+ * @see AllDisabled
+ *
+ * @author Roland Weisleder
+ */
+class AnnotationBasedTogglzExtension extends FeatureManagerExtension {
+
+    @Override
+    TestFeatureManager createTestFeatureManager(ExtensionContext context) {
+        TestFeatureManager featureManager = null;
+
+        Optional<AllEnabled> allEnabled = findAnnotation(context, AllEnabled.class);
+        Optional<AllDisabled> allDisabled = findAnnotation(context, AllDisabled.class);
+        if (allEnabled.isPresent() && allDisabled.isPresent()) {
+            throw new IllegalStateException("Both @AllEnabled and @AllDisabled are present");
+        } else if (allEnabled.isPresent()) {
+            featureManager = new TestFeatureManager(allEnabled.get().value());
+            featureManager.enableAll();
+        } else if (allDisabled.isPresent()) {
+            featureManager = new TestFeatureManager(allDisabled.get().value());
+            featureManager.disableAll();
+        }
+
+        return featureManager;
+    }
+
+    private <T extends Annotation> Optional<T> findAnnotation(ExtensionContext context, Class<T> annotationClass) {
+        Method testMethod = context.getRequiredTestMethod();
+        Optional<T> annotation = AnnotationSupport.findAnnotation(testMethod, annotationClass);
+        if (annotation.isPresent()) {
+            return annotation;
+        }
+
+        Class<?> testClass = context.getRequiredTestClass();
+        return AnnotationSupport.findAnnotation(testClass, annotationClass);
+    }
+}

--- a/junit5/src/main/java/org/togglz/junit5/FeatureManagerExtension.java
+++ b/junit5/src/main/java/org/togglz/junit5/FeatureManagerExtension.java
@@ -1,0 +1,56 @@
+package org.togglz.junit5;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.togglz.core.context.FeatureContext;
+import org.togglz.testing.TestFeatureManager;
+import org.togglz.testing.TestFeatureManagerProvider;
+
+/**
+ * <p>
+ *     JUnit Extension, which sets up a {@link TestFeatureManager} and provides it as parameter to test methods.
+ * </p>
+ *
+ * <p>
+ *     Implementation classes must provide a fully initialized {@link TestFeatureManager}.
+ * </p>
+ *
+ * @see AnnotationBasedTogglzExtension
+ * @see FeatureVariationInvocationContext
+ *
+ * @author Roland Weisleder
+ */
+abstract class FeatureManagerExtension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+    private TestFeatureManager featureManager = null;
+
+    abstract TestFeatureManager createTestFeatureManager(ExtensionContext context);
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        featureManager = createTestFeatureManager(context);
+
+        TestFeatureManagerProvider.setFeatureManager(featureManager);
+        FeatureContext.clearCache();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        TestFeatureManagerProvider.setFeatureManager(null);
+        FeatureContext.clearCache();
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return parameterContext.getParameter().getType().isAssignableFrom(TestFeatureManager.class);
+    }
+
+    @Override
+    public TestFeatureManager resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return featureManager;
+    }
+
+}

--- a/junit5/src/main/java/org/togglz/junit5/FeatureVariationInvocationContext.java
+++ b/junit5/src/main/java/org/togglz/junit5/FeatureVariationInvocationContext.java
@@ -1,0 +1,68 @@
+package org.togglz.junit5;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.joining;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.togglz.core.Feature;
+import org.togglz.testing.TestFeatureManager;
+
+/**
+ * <p>
+ *     Represents a single {@link TestTemplateInvocationContext} created by the {@link FeatureVariationTogglzExtension}
+ *     which contains a set of enabled features.
+ * </p>
+ *
+ * <p>
+ *     This invocation contexts adds a {@link FeatureManagerExtension} to the current test.
+ * </p>
+ *
+ * <p>
+ *     Before executing the test it reports the set of enabled features so others can understand which invocation
+ *     belongs to which feature variation.
+ * </p>
+ *
+ * @see FeatureVariationTogglzExtension
+ * @see FeatureManagerExtension
+ *
+ * @author Roland Weisleder
+ */
+class FeatureVariationInvocationContext implements TestTemplateInvocationContext {
+
+    private final Class<? extends Feature> featureClass;
+
+    private final Set<? extends Feature> enabledFeatures;
+
+    FeatureVariationInvocationContext(Class<? extends Feature> featureClass, Set<? extends Feature> enabledFeatures) {
+        this.featureClass = featureClass;
+        this.enabledFeatures = enabledFeatures;
+    }
+
+    @Override
+    public List<Extension> getAdditionalExtensions() {
+        return singletonList(new FeatureVariantExtension());
+    }
+
+    private class FeatureVariantExtension extends FeatureManagerExtension {
+
+        @Override
+        TestFeatureManager createTestFeatureManager(ExtensionContext context) {
+            TestFeatureManager featureManager = new TestFeatureManager(featureClass);
+            featureManager.disableAll();
+            enabledFeatures.forEach(featureManager::enable);
+            return featureManager;
+        }
+
+        @Override
+        public void beforeEach(ExtensionContext context) {
+            String names = enabledFeatures.stream().map(Feature::name).sorted().collect(joining(", ", "[", "]"));
+            context.publishReportEntry("enabledFeatures", names);
+
+            super.beforeEach(context);
+        }
+    }
+}

--- a/junit5/src/main/java/org/togglz/junit5/FeatureVariationTogglzExtension.java
+++ b/junit5/src/main/java/org/togglz/junit5/FeatureVariationTogglzExtension.java
@@ -1,0 +1,45 @@
+package org.togglz.junit5;
+
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
+import static org.junit.platform.commons.support.ReflectionSupport.newInstance;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.togglz.core.Feature;
+import org.togglz.testing.vary.VariationSet;
+
+/**
+ * <p>
+ *     JUnit Extension to run {@link org.junit.jupiter.api.TestTemplate TestTemplates} with a variation
+ *     of enabled and disabled features.
+ * </p>
+ *
+ * @see VaryFeatures
+ * @see VariationSetProvider
+ *
+ * @author Roland Weisleder
+ */
+class FeatureVariationTogglzExtension implements TestTemplateInvocationContextProvider {
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return true;
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        Optional<VaryFeatures> varyFeatures = context.getElement().flatMap(ae -> findAnnotation(ae, VaryFeatures.class));
+        if (!varyFeatures.isPresent()) {
+            return Stream.empty();
+        }
+
+        VariationSetProvider variationSetProvider = newInstance(varyFeatures.get().value());
+        VariationSet<? extends Feature> variationSet = variationSetProvider.buildVariationSet();
+
+        return variationSet.getVariants().stream()
+            .map(enabledFeatures -> new FeatureVariationInvocationContext(variationSet.getFeatureClass(), enabledFeatures));
+    }
+}

--- a/junit5/src/main/java/org/togglz/junit5/VariationSetProvider.java
+++ b/junit5/src/main/java/org/togglz/junit5/VariationSetProvider.java
@@ -1,0 +1,19 @@
+package org.togglz.junit5;
+
+import org.togglz.core.Feature;
+import org.togglz.testing.vary.VariationSet;
+
+/**
+ * <p>
+ *     Provides of {@link VariationSet} to test templates invoked with {@link VaryFeatures}.
+ * </p>
+ *
+ * @see VaryFeatures
+ *
+ * @author Roland Weisleder
+ */
+public interface VariationSetProvider {
+
+    VariationSet<? extends Feature> buildVariationSet();
+
+}

--- a/junit5/src/main/java/org/togglz/junit5/VaryFeatures.java
+++ b/junit5/src/main/java/org/togglz/junit5/VaryFeatures.java
@@ -1,0 +1,49 @@
+package org.togglz.junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * <p>
+ *     Provides a {@link org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider TestTemplateInvocationContextProvider}
+ *     to run {@link org.junit.jupiter.api.TestTemplate TestTemplates} with a variation of enabled and disabled features.
+ * </p>
+ *
+ * <p>
+ *     Example Usage:
+ * </p>
+ * <pre>
+ *     class PermutationTests {
+ *
+ *         &#064;TestTemplate
+ *         &#064;VaryFeatures(MyVariationSetProvider.class)
+ *         void run() {
+ *             // run testing code ...
+ *             // ONE is enabled
+ *             // TWO is disabled
+ *             // THREE is disabled in the first run and enabled in the second run
+ *         }
+ *
+ *         private static class MyVariationSetProvider implements VariationSetProvider {
+ *
+ *             &#064;Override
+ *             public VariationSet<? extends Feature> buildVariationSet() {
+ *                 return create(MyFeatures.class).enable(MyFeatures.ONE).disable(MyFeatures.TWO).vary(MyFeatures.THREE);
+ *             }
+ *         }
+ *     }
+ * </pre>
+ *
+ * @author Roland Weisleder
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@ExtendWith(FeatureVariationTogglzExtension.class)
+public @interface VaryFeatures {
+
+    Class<? extends VariationSetProvider> value();
+
+}

--- a/junit5/src/test/java/org/togglz/junit5/AnnotationBasedTogglzExtensionTest.java
+++ b/junit5/src/test/java/org/togglz/junit5/AnnotationBasedTogglzExtensionTest.java
@@ -1,0 +1,69 @@
+package org.togglz.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.togglz.testing.TestFeatureManager;
+
+/**
+ * @author Roland Weisleder
+ */
+class AnnotationBasedTogglzExtensionTest {
+
+    @Test
+    @AllEnabled(MyFeatures.class)
+    void allEnabled() {
+        assertTrue(MyFeatures.ONE.isActive());
+        assertTrue(MyFeatures.TWO.isActive());
+        assertTrue(MyFeatures.THREE.isActive());
+    }
+
+    @Test
+    @AllDisabled(MyFeatures.class)
+    void allDisabled() {
+        assertFalse(MyFeatures.ONE.isActive());
+        assertFalse(MyFeatures.TWO.isActive());
+        assertFalse(MyFeatures.THREE.isActive());
+    }
+
+    @Test
+    @AllEnabled(MyFeatures.class)
+    void testFeatureManagerParameter(TestFeatureManager featureManager) {
+        assertTrue(MyFeatures.ONE.isActive());
+
+        featureManager.disable(MyFeatures.ONE);
+        assertFalse(MyFeatures.ONE.isActive());
+
+        featureManager.enable(MyFeatures.ONE);
+        assertTrue(MyFeatures.ONE.isActive());
+    }
+
+    @Nested
+    @AllEnabled(MyFeatures.class)
+    class AllEnabledClassTest {
+
+        @Test
+        void allEnabled() {
+            assertTrue(MyFeatures.ONE.isActive());
+            assertTrue(MyFeatures.TWO.isActive());
+            assertTrue(MyFeatures.THREE.isActive());
+        }
+
+    }
+
+    @Nested
+    @AllDisabled(MyFeatures.class)
+    class AllDisabledClassTest {
+
+        @Test
+        void allDisabled() {
+            assertFalse(MyFeatures.ONE.isActive());
+            assertFalse(MyFeatures.TWO.isActive());
+            assertFalse(MyFeatures.THREE.isActive());
+        }
+
+    }
+
+}

--- a/junit5/src/test/java/org/togglz/junit5/FeatureVariationTogglzExtensionTest.java
+++ b/junit5/src/test/java/org/togglz/junit5/FeatureVariationTogglzExtensionTest.java
@@ -1,0 +1,34 @@
+package org.togglz.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.togglz.testing.vary.VariationSetBuilder.create;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.togglz.core.Feature;
+import org.togglz.testing.vary.VariationSet;
+
+/**
+ * @author Roland Weisleder
+ */
+class FeatureVariationTogglzExtensionTest {
+
+    @TestTemplate
+    @VaryFeatures(TestingVariationSetProvider.class)
+    void variations() {
+        assertTrue(MyFeatures.ONE.isActive());
+        assertFalse(MyFeatures.TWO.isActive());
+
+        // active or not active, that is the question
+        assertTrue(MyFeatures.THREE.isActive() || !MyFeatures.THREE.isActive());
+    }
+
+    private static class TestingVariationSetProvider implements VariationSetProvider {
+
+        @Override
+        public VariationSet<? extends Feature> buildVariationSet() {
+            return create(MyFeatures.class).enable(MyFeatures.ONE).disable(MyFeatures.TWO).vary(MyFeatures.THREE);
+        }
+    }
+
+}

--- a/junit5/src/test/java/org/togglz/junit5/MyFeatures.java
+++ b/junit5/src/test/java/org/togglz/junit5/MyFeatures.java
@@ -1,0 +1,16 @@
+package org.togglz.junit5;
+
+import org.togglz.core.Feature;
+import org.togglz.core.context.FeatureContext;
+
+/**
+ * @author Roland Weisleder
+ */
+enum MyFeatures implements Feature {
+
+    ONE, TWO, THREE;
+
+    public boolean isActive() {
+        return FeatureContext.getFeatureManager().isActive(this);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.12</version>
+          <version>2.19.1</version>
         </plugin>
 
         <plugin>
@@ -304,6 +304,7 @@
       </activation>
       <modules>
         <module>microprofile-config</module>
+        <module>junit5</module>
       </modules>
     </profile>
 

--- a/testing/src/main/java/org/togglz/testing/vary/VariationSet.java
+++ b/testing/src/main/java/org/togglz/testing/vary/VariationSet.java
@@ -5,9 +5,9 @@ import java.util.Set;
 import org.togglz.core.Feature;
 
 /**
- * This class represents a set of feature state variants. It is used to configure unit test that are executed with JUnit Runner
- * "FeatureVariations". The common implementation of this interface is {@link VariationSetBuilder} which allows to build
- * sets dynamically.
+ * This class represents a set of feature state variants. It is used to configure unit test that are executed with
+ * FeatureVariations (JUnit 4 integration) or VaryFeatures (JUnit 5 integration). The common implementation of this interface
+ * is {@link VariationSetBuilder} which allows to build sets dynamically.
  * 
  * @author Christian Kaltepoth
  * 

--- a/testing/src/main/java/org/togglz/testing/vary/VariationSet.java
+++ b/testing/src/main/java/org/togglz/testing/vary/VariationSet.java
@@ -1,0 +1,25 @@
+package org.togglz.testing.vary;
+
+import java.util.Set;
+
+import org.togglz.core.Feature;
+
+/**
+ * This class represents a set of feature state variants. It is used to configure unit test that are executed with JUnit Runner
+ * "FeatureVariations". The common implementation of this interface is {@link VariationSetBuilder} which allows to build
+ * sets dynamically.
+ * 
+ * @author Christian Kaltepoth
+ * 
+ * @see VariationSetBuilder
+ * @param <F> The feature class
+ */
+public interface VariationSet<F extends Feature> {
+
+    Class<F> getFeatureClass();
+
+    /**
+     * Build the variant set data structure from the current configuration of the class.
+     */
+    Set<Set<F>> getVariants();
+}

--- a/testing/src/main/java/org/togglz/testing/vary/VariationSetBuilder.java
+++ b/testing/src/main/java/org/togglz/testing/vary/VariationSetBuilder.java
@@ -1,0 +1,149 @@
+package org.togglz.testing.vary;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.togglz.core.Feature;
+import org.togglz.core.util.Validate;
+
+/**
+ * Default implementation of {@link VariationSet} that allows to build the set dynamically.
+ * 
+ * @author Christian Kaltepoth
+ * 
+ * @param <F> The feature class
+ */
+public class VariationSetBuilder<F extends Feature> implements VariationSet<F>
+{
+
+    public static <F extends Feature> VariationSetBuilder<F> create(Class<F> featureClass)
+    {
+        return new VariationSetBuilder<F>(featureClass);
+    }
+
+    private final Class<F> featureClass;
+
+    private final Set<F> featuresToVary = new HashSet<F>();
+    private final Set<F> featuresToEnable = new HashSet<F>();
+    private final Set<F> featuresToDisable = new HashSet<F>();
+
+    protected VariationSetBuilder(Class<F> featureEnum)
+    {
+        Validate.notNull(featureEnum, "The featureEnum argument is required");
+        Validate.isTrue(featureEnum.isEnum(), "This class only works with feature enums");
+        this.featureClass = featureEnum;
+    }
+
+    /**
+     * Vary this feature in the variation set.
+     */
+    public VariationSetBuilder<F> vary(F f)
+    {
+        featuresToVary.add(f);
+        featuresToEnable.remove(f);
+        featuresToDisable.remove(f);
+        return this;
+    }
+
+    /**
+     * Enable this feature in the variation set.
+     */
+    public VariationSetBuilder<F> enable(F f)
+    {
+        featuresToVary.remove(f);
+        featuresToEnable.add(f);
+        featuresToDisable.remove(f);
+        return this;
+    }
+
+    /**
+     * Disable this feature in the variation set.
+     */
+    public VariationSetBuilder<F> disable(F f)
+    {
+        featuresToVary.remove(f);
+        featuresToEnable.remove(f);
+        featuresToDisable.add(f);
+        return this;
+    }
+
+    /**
+     * Enable all features in the variation set.
+     */
+    public VariationSetBuilder<F> enableAll() {
+        for (F f : featureClass.getEnumConstants()) {
+            enable(f);
+        }
+        return this;
+    }
+
+    /**
+     * Disable all features in the variation set.
+     */
+    public VariationSetBuilder<F> disableAll() {
+        for (F f : featureClass.getEnumConstants()) {
+            disable(f);
+        }
+        return this;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.togglz.junit.vary.VariationSet#getVariants()
+     */
+    @Override
+    public Set<Set<F>> getVariants()
+    {
+
+        // start with a single variant with all feature disabled
+        Set<Set<F>> variantSet = new LinkedHashSet<Set<F>>();
+        variantSet.add(new HashSet<F>());
+
+        for (F feature : featureClass.getEnumConstants()) {
+
+            // enable the feature in all variants
+            if (featuresToEnable.contains(feature)) {
+                for (Set<F> variant : variantSet) {
+                    variant.add(feature);
+                }
+            }
+
+            // disable the feature in all variants
+            else if (featuresToDisable.contains(feature)) {
+                for (Set<F> variant : variantSet) {
+                    variant.remove(feature);
+                }
+            }
+
+            // copy the existing variants, enable the feature in the copy, and merge them
+            else if (featuresToVary.contains(feature)) {
+                Set<Set<F>> copy = deepCopy(variantSet);
+                for (Set<F> variant : copy) {
+                    variant.add(feature);
+                }
+                variantSet.addAll(copy);
+            }
+
+        }
+
+        return variantSet;
+
+    }
+
+    private Set<Set<F>> deepCopy(Set<Set<F>> src) {
+        Set<Set<F>> copy = new LinkedHashSet<Set<F>>();
+        for (Set<F> variant : src) {
+            copy.add(new HashSet<F>(variant));
+        }
+        return copy;
+    }
+
+    @Override
+    public Class<F> getFeatureClass()
+    {
+        return featureClass;
+    }
+
+}


### PR DESCRIPTION
This PR adds support for JUnit 5. Have a look at the test cases how to use the extensions.

Basically `@AllEnabled` and `@AllDisabled` are the same as `TogglzRule.allEnabled` and `TogglzRule.allDisabled`. To enable a single feature among all disabled features, the `TestFeatureManager` is available as [test parameter](http://junit.org/junit5/docs/current/user-guide/#writing-tests-dependency-injection).

`@VaryFeatures` is basically the same as `@RunWith(FeatureVariations.class)`.
I reused the `VariationSet` and `VariationSetBuilder` from `togglz-junit`. But I would be happier to move these classes to togglz-testing and omit the dependency to `togglz-junit`.

JUnit 5 requires Java 8 at runtime, so the compile source and target for the new maven module is 1.8.
The CI build will fail with JDK 7!

If merged this resolves #245 