### PR TITLE
Calling getFeatureState twice

### DIFF
--- a/core/src/main/java/org/togglz/core/repository/composite/CompositeStateRepository.java
+++ b/core/src/main/java/org/togglz/core/repository/composite/CompositeStateRepository.java
@@ -74,7 +74,7 @@ public class CompositeStateRepository implements StateRepository {
         for (StateRepository repository : iterationOrder.getSelected(repositories)) {
             FeatureState featureState = repository.getFeatureState(feature);
             if (featureState != null) {
-                return featureState
+                return featureState;
             }
         }
         

--- a/core/src/main/java/org/togglz/core/repository/composite/CompositeStateRepository.java
+++ b/core/src/main/java/org/togglz/core/repository/composite/CompositeStateRepository.java
@@ -74,7 +74,7 @@ public class CompositeStateRepository implements StateRepository {
         for (StateRepository repository : iterationOrder.getSelected(repositories)) {
             FeatureState featureState = repository.getFeatureState(feature);
             if (featureState != null) {
-                return repository.getFeatureState(feature);
+                return featureState
             }
         }
         


### PR DESCRIPTION
As part of attempting to debug an issue with composite feature states, I found that `CompositFeatureState.getFeatureState(feature)` calls `getFeatureState()` of the child repository twice.

This seems like a benign thing, but it may result in doubling of the read load on the child feature store.