### PR TITLE
Ensure FeatureState changes are not automaticaly "persisted" in InMemoryStateRepository

### DIFF
--- a/core/src/main/java/org/togglz/core/repository/FeatureState.java
+++ b/core/src/main/java/org/togglz/core/repository/FeatureState.java
@@ -17,7 +17,7 @@ import org.togglz.core.util.Strings;
 
 /**
  * This class represents the state of a feature that is persisted by {@link StateRepository} implementations.
- * 
+ *
  * @author Christian Kaltepoth
  */
 public class FeatureState implements Serializable {
@@ -27,12 +27,12 @@ public class FeatureState implements Serializable {
     private final Feature feature;
     private boolean enabled;
     private String strategyId;
-    private final Map<String, String> parameters = new HashMap<String, String>();
+    private final Map<String, String> parameters = new HashMap<>();
 
     /**
      * This constructor creates a new feature state for the given feature. The feature is initially disabled if this constructor
      * is used.
-     * 
+     *
      * @param feature The feature that is represented by this state.
      */
     public FeatureState(Feature feature) {
@@ -41,7 +41,7 @@ public class FeatureState implements Serializable {
 
     /**
      * This constructor creates a new feature state for the given feature.
-     * 
+     *
      * @param feature The feature that is represented by this state.
      * @param enabled boolean indicating whether this feature should be enabled or not.
      */
@@ -53,11 +53,11 @@ public class FeatureState implements Serializable {
     /**
      * This constructor creates a new feature state for the given feature. Please not that using this constructor will
      * automatically set strategyId to match the {@link UsernameActivationStrategy}.
-     * 
+     *
      * @param feature The feature that is represented by this state.
      * @param enabled boolean indicating whether this feature should be enabled or not.
      * @param users A list of users
-     * 
+     *
      * @deprecated This constructor will be removed soon. You should use {@link #FeatureState(Feature, boolean)} and
      *             {@link #setParameter(String, String)} instead.
      */
@@ -84,7 +84,7 @@ public class FeatureState implements Serializable {
 
     /**
      * Returns the feature represented by this feature state.
-     * 
+     *
      * @return The feature, never <code>null</code>
      */
     public Feature getFeature() {
@@ -122,9 +122,9 @@ public class FeatureState implements Serializable {
 
     /**
      * The list of users associated with the feature state.
-     * 
+     *
      * @return The user list, never <code>null</code>
-     * 
+     *
      * @deprecated This method will be removed soon. Use {@link #getParameter(String)} instead to read the corresponding
      *             strategy parameter.
      */
@@ -139,7 +139,7 @@ public class FeatureState implements Serializable {
 
     /**
      * Adds a single user to the list of users
-     * 
+     *
      * @deprecated This method will be removed soon. Use {@link #setParameter(String, String)} instead to modify the
      *             corresponding strategy parameter.
      */
@@ -150,13 +150,13 @@ public class FeatureState implements Serializable {
 
     /**
      * Adds a single user to the list of users
-     * 
+     *
      * @deprecated This method will be removed soon. Use {@link #setParameter(String, String)} instead to modify the
      *             corresponding strategy parameter.
      */
     @Deprecated
     public FeatureState addUsers(Collection<String> users) {
-        Set<String> set = new LinkedHashSet<String>();
+        Set<String> set = new LinkedHashSet<>();
         set.addAll(this.getUsers());
         set.addAll(users);
         String setAsString = Strings.trimToNull(Strings.join(set, ","));
@@ -213,4 +213,11 @@ public class FeatureState implements Serializable {
         return Collections.unmodifiableMap(this.parameters);
     }
 
+    /**
+     * Returns a copy of a featureState, or <code>null</code> if the featureState is
+     * <code>null</code>.
+     */
+    public static FeatureState copyOf(FeatureState featureState) {
+        return featureState == null ? null : featureState.copy();
+    }
 }

--- a/core/src/main/java/org/togglz/core/repository/mem/InMemoryStateRepository.java
+++ b/core/src/main/java/org/togglz/core/repository/mem/InMemoryStateRepository.java
@@ -9,23 +9,25 @@ import org.togglz.core.repository.StateRepository;
 
 
 /**
- * 
+ *
  * A very simply implementation of {@link StateRepository} entirely on memory. This class is typically only used for
  * integration tests or at development time.
- * 
+ *
  * @author Christian Kaltepoth
- * 
+ *
  */
 public class InMemoryStateRepository implements StateRepository {
 
-    private final Map<String, FeatureState> states = new ConcurrentHashMap<String, FeatureState>();
+    private final Map<String, FeatureState> states = new ConcurrentHashMap<>();
 
+    @Override
     public FeatureState getFeatureState(Feature feature) {
-        return states.get(feature.name());
+        return FeatureState.copyOf(states.get(feature.name()));
     }
 
+    @Override
     public void setFeatureState(FeatureState featureState) {
-        states.put(featureState.getFeature().name(), featureState);
+        states.put(featureState.getFeature().name(), FeatureState.copyOf(featureState));
     }
 
 }

--- a/core/src/test/java/org/togglz/core/repository/mem/InMemoryStateRepositoryTest.java
+++ b/core/src/test/java/org/togglz/core/repository/mem/InMemoryStateRepositoryTest.java
@@ -1,0 +1,62 @@
+package org.togglz.core.repository.mem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.togglz.core.Feature;
+import org.togglz.core.repository.FeatureState;
+
+public class InMemoryStateRepositoryTest {
+
+    private InMemoryStateRepository repository;
+
+    @Before
+    public void before() throws SQLException {
+        repository = new InMemoryStateRepository();
+    }
+
+    @Test
+    public void testGetFeatureStateNotSameAsSetFeatureState() {
+        FeatureState featureState = createDisabledFeatureState();
+        repository.setFeatureState(featureState);
+        FeatureState featureStateFromRepo = repository.getFeatureState(MyFeature.FEATURE1);
+        assertThat(featureStateFromRepo).isNotSameAs(featureState);
+    }
+
+    @Test
+    public void testGetFeatureStateChangeNotAffectsInternalRepositoryState() {
+        repository.setFeatureState(createDisabledFeatureState());
+        FeatureState featureStateFromRepo = repository.getFeatureState(MyFeature.FEATURE1);
+        assertThat(featureStateFromRepo.isEnabled()).isFalse();
+        // change feature state but not "persist" it (we don't call repository.setFeatureState)
+        featureStateFromRepo.setEnabled(true);
+        // obtain persisted feature again
+        featureStateFromRepo = repository.getFeatureState(MyFeature.FEATURE1);
+        assertThat(featureStateFromRepo.isEnabled()).isFalse();
+    }
+
+    @Test
+    public void testSetFeatureStateChangeNotAffectsInternalRepositoryState() {
+        FeatureState featureState = createDisabledFeatureState();
+        repository.setFeatureState(featureState);
+        // change feature state after "persisting" it
+        featureState.setEnabled(true);
+        // obtain persisted feature
+        FeatureState featureStateFromRepo = repository.getFeatureState(MyFeature.FEATURE1);
+        assertThat(featureStateFromRepo.isEnabled()).isFalse();
+    }
+
+    protected FeatureState createDisabledFeatureState() {
+        FeatureState featureState = new FeatureState(MyFeature.FEATURE1);
+        featureState.setEnabled(false);
+        return featureState;
+    }
+
+    private static enum MyFeature implements Feature {
+        FEATURE1,
+        FEATURE2
+    }
+}

--- a/spring-core/src/main/java/org/togglz/spring/repository/FeatureStateChangedEvent.java
+++ b/spring-core/src/main/java/org/togglz/spring/repository/FeatureStateChangedEvent.java
@@ -6,7 +6,7 @@ import org.togglz.core.repository.FeatureState;
 
 /**
  * An {@link ApplicationEvent} that is published whenever a {@link FeatureState} is changed
- * 
+ *
  * @author Igor Khudoshin
  */
 public class FeatureStateChangedEvent extends ApplicationEvent {
@@ -23,7 +23,7 @@ public class FeatureStateChangedEvent extends ApplicationEvent {
     }
 
     public FeatureStateChangedEvent(FeatureState previousFeatureState, FeatureState featureState) {
-        super(featureState);
-        this.previousFeatureState = previousFeatureState;
+        super(FeatureState.copyOf(featureState));
+        this.previousFeatureState = FeatureState.copyOf(previousFeatureState);
     }
 }


### PR DESCRIPTION
Prevents scenarios where a `FeatureState` is set into `InMemoryStateRepository`
but is changed after without an explicit call to
`InMemoryStateRepository.setFeatureState`. In thoses cases, we still
want to return an object with the state that was stored, not the current
changed one, to be consistent with other `StateRepositories`, like
`JDBCStateRepository`.

We always store and return copies of `FeatureState` in `InMemoryStateRepository`
to prevent mutability of those states.