### PR TITLE
Removed hardcoded reference to Spring 3.0 from some tests.

### DIFF
--- a/spring-web/src/test/java/org/togglz/spring/test/SpringBasicOperationTest.java
+++ b/spring-web/src/test/java/org/togglz/spring/test/SpringBasicOperationTest.java
@@ -11,6 +11,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.core.SpringVersion;
 import org.togglz.test.Deployments;
 import org.togglz.test.Packaging;
 
@@ -25,7 +26,7 @@ public class SpringBasicOperationTest {
         return Deployments.getBasicWebArchive()
             .addAsLibrary(Deployments.getTogglzSpringArchive())
             .addAsLibraries(Packaging.mavenDependencies()
-                .artifact("org.springframework:spring-web:3.0.7.RELEASE")
+                .artifact("org.springframework:spring-web:" + SpringVersion.getVersion())
                 .asFiles())
             .addAsWebInfResource("applicationContext.xml")
             .setWebXML("spring-web.xml")

--- a/spring-web/src/test/java/org/togglz/spring/test/SpringEarlyFeatureUsageTest.java
+++ b/spring-web/src/test/java/org/togglz/spring/test/SpringEarlyFeatureUsageTest.java
@@ -9,6 +9,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.core.SpringVersion;
 import org.springframework.web.context.ContextLoader;
 import org.springframework.web.context.WebApplicationContext;
 import org.togglz.test.Deployments;
@@ -22,7 +23,7 @@ public class SpringEarlyFeatureUsageTest {
         return Deployments.getBasicWebArchive()
             .addAsLibrary(Deployments.getTogglzSpringArchive())
             .addAsLibraries(Packaging.mavenDependencies()
-                .artifact("org.springframework:spring-web:3.0.7.RELEASE")
+                .artifact("org.springframework:spring-web:" + SpringVersion.getVersion())
                 .asFiles())
             .addAsWebInfResource("applicationContext.xml")
             .setWebXML("spring-web.xml")

--- a/spring-web/src/test/java/org/togglz/spring/test/container/ManagedFeatureManagerTest.java
+++ b/spring-web/src/test/java/org/togglz/spring/test/container/ManagedFeatureManagerTest.java
@@ -7,6 +7,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.core.SpringVersion;
 import org.togglz.core.context.FeatureContext;
 import org.togglz.spring.test.BasicFeatures;
 import org.togglz.test.Deployments;
@@ -20,7 +21,7 @@ public class ManagedFeatureManagerTest {
         return Deployments.getBasicWebArchive()
             .addAsLibrary(Deployments.getTogglzSpringArchive())
             .addAsLibraries(Packaging.mavenDependencies()
-                    .artifact("org.springframework:spring-web:3.0.7.RELEASE")
+                    .artifact("org.springframework:spring-web:" + SpringVersion.getVersion())
                     .asFiles())
             .addClass(BasicFeatures.class)
             .addAsWebInfResource("applicationContext-container.xml")

--- a/spring-web/src/test/java/org/togglz/spring/test/proxy/FeatureProxyTest.java
+++ b/spring-web/src/test/java/org/togglz/spring/test/proxy/FeatureProxyTest.java
@@ -10,6 +10,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.core.SpringVersion;
 import org.springframework.web.context.ContextLoader;
 import org.springframework.web.context.WebApplicationContext;
 import org.togglz.core.context.FeatureContext;
@@ -25,7 +26,7 @@ public class FeatureProxyTest {
         return Deployments.getBasicWebArchive()
             .addAsLibrary(Deployments.getTogglzSpringArchive())
             .addAsLibraries(Packaging.mavenDependencies()
-                .artifact("org.springframework:spring-web:3.0.7.RELEASE")
+                .artifact("org.springframework:spring-web:" + SpringVersion.getVersion())
                 .asFiles())
             .addAsWebInfResource("applicationContext.xml")
             .addAsWebInfResource("applicationContext-proxy.xml")


### PR DESCRIPTION
This PR removes the hardcoded Spring 3.0 reference by calling `org.springframework.core.SpringVersion.getVersion()'.
Confirmed that this fixes the issue by running #280 with this patch.