### PR TITLE
Fix condition preventing console from being disabled

### DIFF
--- a/spring-boot/autoconfigure/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzConsoleBaseConfiguration.java
+++ b/spring-boot/autoconfigure/src/main/java/org/togglz/spring/boot/autoconfigure/TogglzConsoleBaseConfiguration.java
@@ -57,26 +57,31 @@ public abstract class TogglzConsoleBaseConfiguration {
         return "";
     }
 
-    static class OnConsoleEnabled extends AllNestedConditions {
+    public static class OnConsoleAndUseManagementPort extends AllNestedConditions {
 
-        OnConsoleEnabled() {
+        OnConsoleAndUseManagementPort() {
             super(ConfigurationPhase.PARSE_CONFIGURATION);
         }
 
         @ConditionalOnProperty(prefix = "togglz.console", name = "enabled", matchIfMissing = true)
         static class OnConsole {
         }
-    }
-
-    public static class OnConsoleAndUseManagementPort extends OnConsoleEnabled {
-
+        
         @ConditionalOnProperty(prefix = "togglz.console", name = "use-management-port", havingValue = "true", matchIfMissing = true)
         static class OnUseManagementPort {
         }
 
     }
 
-    public static class OnConsoleAndNotUseManagementPort extends OnConsoleEnabled {
+    public static class OnConsoleAndNotUseManagementPort extends AllNestedConditions {
+
+        OnConsoleAndNotUseManagementPort() {
+            super(ConfigurationPhase.PARSE_CONFIGURATION);
+        }
+
+        @ConditionalOnProperty(prefix = "togglz.console", name = "enabled", matchIfMissing = true)
+        static class OnConsole {
+        }
 
         @ConditionalOnProperty(prefix = "togglz.console", name = "use-management-port", havingValue = "false")
         static class OnNotUseManagementPort {

--- a/spring-boot/autoconfigure/src/test/java/org/togglz/spring/boot/autoconfigure/TogglzAutoConfigurationTest.java
+++ b/spring-boot/autoconfigure/src/test/java/org/togglz/spring/boot/autoconfigure/TogglzAutoConfigurationTest.java
@@ -175,6 +175,13 @@ public class TogglzAutoConfigurationTest {
                 "togglz.console.enabled: false");
         assertEquals(0, this.context.getBeansOfType(ServletRegistrationBean.class).size());
     }
+    
+    @Test
+    public void consoleDisabledWithoutUseManagementPort() {
+        loadWithDefaults(new Class[]{FeatureProviderConfig.class},
+                "togglz.console.enabled: false", "togglz.console.use-management-port: false");
+        assertEquals(0, this.context.getBeansOfType(ServletRegistrationBean.class).size());
+    }
 
     @Test
     public void consoleUseManagementPortIsFalseWithoutTogglzManagementContextConfiguration() {


### PR DESCRIPTION
`OnConsoleAndNotUseManagementPort` condition was not working as
expected

Fixes: #298