### PR TITLE
Exchanging Response code 403 Forbidden to 400 Bad Request

### DIFF
--- a/console/src/main/java/org/togglz/console/handlers/edit/EditPageHandler.java
+++ b/console/src/main/java/org/togglz/console/handlers/edit/EditPageHandler.java
@@ -48,7 +48,7 @@ public class EditPageHandler extends RequestHandlerBase {
             }
         }
         if (feature == null) {
-            response.sendError(403);
+            response.sendError(400);
             return;
         }
 


### PR DESCRIPTION
this makes it easier to distinguish errors caused by wrong requests against authentification issues.

