### PR TITLE
Add OWASP dependency check plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: java
+cache:
+  directories:
+    - $HOME/.m2/repository/org/owasp/dependency-check-data/
 install:
   - "mvn -P ${CONTAINER} -DJBOSS_REPO=true -DskipTests=true -B install"
 script:

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
           <suppressionFiles>
             <suppressionFile>project-suppression.xml</suppressionFile>
           </suppressionFiles>
+          <skipArtifactType>pom</skipArtifactType>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,25 @@
         </configuration>
       </plugin>
 
+      <!-- OWASP -->
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>5.2.2</version>
+        <configuration>
+          <skipProvidedScope>true</skipProvidedScope>
+          <skipRuntimeScope>true</skipRuntimeScope>
+          <skipSystemScope>true</skipSystemScope>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>aggregate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
 
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
         <artifactId>dependency-check-maven</artifactId>
         <version>5.2.2</version>
         <configuration>
+          <format>ALL</format>
           <skipProvidedScope>true</skipProvidedScope>
           <skipRuntimeScope>true</skipRuntimeScope>
           <skipSystemScope>true</skipSystemScope>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,9 @@
           <skipProvidedScope>true</skipProvidedScope>
           <skipRuntimeScope>true</skipRuntimeScope>
           <skipSystemScope>true</skipSystemScope>
+          <suppressionFiles>
+            <suppressionFile>project-suppression.xml</suppressionFile>
+          </suppressionFiles>
         </configuration>
         <executions>
           <execution>

--- a/project-suppression.xml
+++ b/project-suppression.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes>False positive: found because of name "hazelcast" in module name - possible security
+            issues resulting from used hazelcast library will be found nevertheless.</notes>
+        <packageUrl regex="true">^pkg:maven/org\.togglz/togglz\-hazelcast@.*$</packageUrl>
+        <cpe>cpe:/a:hazelcast:hazelcast</cpe>
+    </suppress>
+    <suppress>
+        <notes>False positive: CVE-2016-3093 describes as vulnerability in the Struts framework in
+            combination with the ognl library.</notes>
+        <packageUrl regex="true">^pkg:maven/ognl/ognl@.*$</packageUrl>
+        <cve>CVE-2016-3093</cve>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
Added OWASP dependency check plugin and suppressed false positive findings.
Currently the integration is not failing builds but generating one aggregate report in `target/dependency-check-report.html`. Before thinking about using automatically breaking builds we should first fix all existing findings.

I currently have no clue how to make the results from the Travis build available in some human readable way. The OWASP dependency check plugin generates a quite useful HTML report but I've not found a way yet to make accessible in Travis :-/.

Fixes #328 