### PR TITLE
Adds ListenableStateRepository delegate

### DIFF
--- a/core/src/main/java/org/togglz/core/repository/listener/FeatureStateChangedListener.java
+++ b/core/src/main/java/org/togglz/core/repository/listener/FeatureStateChangedListener.java
@@ -1,0 +1,26 @@
+package org.togglz.core.repository.listener;
+
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.util.Weighted;
+
+
+/**
+ * A listener for feature-state changes.
+ */
+public interface FeatureStateChangedListener extends Weighted {
+
+    /**
+     * Callback method that is called by {@link ListenableStateRepository} instances, when
+     * {@link org.togglz.core.repository.StateRepository#setFeatureState(FeatureState)} is
+     * called.
+     *
+     * <p>
+     *     The method is invoked after the update in the {@code StateRepository}.
+     * </p>
+     *
+     * @param fromState the previous {@link FeatureState feature state} of the {@link org.togglz.core.Feature feature}
+     * @param toState the new value of the FeatureState
+     */
+    void onFeatureStateChanged(FeatureState fromState, FeatureState toState);
+
+}

--- a/core/src/main/java/org/togglz/core/repository/listener/ListenableStateRepository.java
+++ b/core/src/main/java/org/togglz/core/repository/listener/ListenableStateRepository.java
@@ -1,0 +1,47 @@
+package org.togglz.core.repository.listener;
+
+import org.togglz.core.Feature;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.repository.StateRepository;
+import org.togglz.core.util.Weighted;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class ListenableStateRepository implements StateRepository {
+    private static final Weighted.WeightedComparator WEIGHTED_COMPARATOR = new Weighted.WeightedComparator();
+    private final List<FeatureStateChangedListener> listeners;
+    private final StateRepository delegate;
+
+    public ListenableStateRepository(final StateRepository delegate,
+                                     final Collection<FeatureStateChangedListener> listeners) {
+        this.delegate = delegate;
+        this.listeners = new CopyOnWriteArrayList<>(listeners);
+        this.listeners.sort(WEIGHTED_COMPARATOR);
+    }
+
+    public ListenableStateRepository(final StateRepository delegate,
+                                     final FeatureStateChangedListener... listeners) {
+        this.delegate = delegate;
+        this.listeners = new CopyOnWriteArrayList<>(listeners);
+        this.listeners.sort(WEIGHTED_COMPARATOR);
+    }
+
+    public final void addFeatureStateChangedListener(final FeatureStateChangedListener listener) {
+        listeners.add(listener);
+        listeners.sort(WEIGHTED_COMPARATOR);
+    }
+
+    @Override
+    public FeatureState getFeatureState(final Feature feature) {
+        return delegate.getFeatureState(feature);
+    }
+
+    @Override
+    public void setFeatureState(final FeatureState featureState) {
+        final FeatureState fromState = getFeatureState(featureState.getFeature());
+        delegate.setFeatureState(featureState);
+        listeners.forEach(listener -> listener.onFeatureStateChanged(fromState, featureState));
+    }
+}

--- a/core/src/test/java/org/togglz/core/repository/listener/ListenableStateRepositoryTest.java
+++ b/core/src/test/java/org/togglz/core/repository/listener/ListenableStateRepositoryTest.java
@@ -1,0 +1,80 @@
+package org.togglz.core.repository.listener;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.togglz.core.Feature;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.repository.StateRepository;
+import org.togglz.core.repository.mem.InMemoryStateRepository;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class ListenableStateRepositoryTest {
+
+    private StateRepository delegate;
+
+    @Before
+    public void setup() {
+        delegate = new InMemoryStateRepository();
+    }
+
+    @Test
+    public void shouldReturnNullForUnknownFeature() {
+        final ListenableStateRepository repo = new ListenableStateRepository(delegate);
+        assertNull(repo.getFeatureState(TestFeature.F1));
+    }
+
+    @Test
+    public void shouldGetFeatureFromDelegate() {
+        final ListenableStateRepository repo = new ListenableStateRepository(delegate);
+        delegate.setFeatureState(new FeatureState(TestFeature.F1, true));
+        
+        assertTrue(repo.getFeatureState(TestFeature.F1).isEnabled());
+    }
+
+    @Test
+    public void shouldSetFeatureInDelegate() {
+        final ListenableStateRepository repo = new ListenableStateRepository(delegate);
+        repo.setFeatureState(new FeatureState(TestFeature.F1, true));
+
+        assertTrue(delegate.getFeatureState(TestFeature.F1).isEnabled());
+    }
+
+    @Test
+    public void shouldNotifyListenersAfterSet() {
+        FeatureStateChangedListener firstListener = mock(FeatureStateChangedListener.class);
+        FeatureStateChangedListener secondListener = mock(FeatureStateChangedListener.class);
+        final ListenableStateRepository repo = new ListenableStateRepository(delegate);
+        repo.addFeatureStateChangedListener(firstListener);
+        repo.addFeatureStateChangedListener(secondListener);
+
+        FeatureState toFeatureState = new FeatureState(TestFeature.F1, true);
+        repo.setFeatureState(toFeatureState);
+
+        verify(firstListener, times(1)).onFeatureStateChanged(null, toFeatureState);
+        verify(secondListener, times(1)).onFeatureStateChanged(null, toFeatureState);
+    }
+
+    @Test
+    public void shouldNotifyListenersInWeightedOrder() {
+        FeatureStateChangedListener higherPrio = mock(FeatureStateChangedListener.class);
+        when(higherPrio.priority()).thenReturn(42);
+        FeatureStateChangedListener lowerPrio = mock(FeatureStateChangedListener.class);
+        when(lowerPrio.priority()).thenReturn(7);
+        InOrder inOrder = inOrder(higherPrio, lowerPrio);
+
+        final ListenableStateRepository repo = new ListenableStateRepository(delegate, higherPrio, lowerPrio);
+        final FeatureState featureState = new FeatureState(TestFeature.F1, true);
+        repo.setFeatureState(featureState);
+
+        inOrder.verify(lowerPrio, times(1)).onFeatureStateChanged(null, featureState);
+        inOrder.verify(higherPrio, times(1)).onFeatureStateChanged(null, featureState);
+    }
+
+    enum TestFeature implements Feature {
+        F1
+    }
+}


### PR DESCRIPTION
Adds ListenableStateRepository delegate to address callback-requirement #178.
This is the most simple solution to solve the requirement without having to change any of the interfaces. 