### PR TITLE
TogglzTestExecutionListener - If not enabled by default, state cannot be enabled

### DIFF
--- a/spring-core/src/main/java/org/togglz/spring/test/TogglzTestExecutionListener.java
+++ b/spring-core/src/main/java/org/togglz/spring/test/TogglzTestExecutionListener.java
@@ -37,8 +37,6 @@ public class TogglzTestExecutionListener extends AbstractTestExecutionListener {
 			FeatureState state = manager.getFeatureState(feature);
 			if (defaults.isEnabled()) {
 				state.enable();
-			} else {
-				state.disable();
 			}
 			manager.setFeatureState(state);
 		}


### PR DESCRIPTION
I would like to propose this change, because in case of the DefaultsFeatureManager the state will be everytime false, although it is configured different. So perhaps this could be a good option. When defaults isEnabled then change the state to enabled and otherwise the state should be as it is, so the explicit configuration of the feature toggle will be used. 

Perhaps it could be an option to delete line 36 because the default from meta data is gets checked in getFeatureState too, if the state of the feature is null. Am I wrong with it?