### PR TITLE
Add HeaderActivationStrategy

### DIFF
--- a/servlet/src/main/java/org/togglz/servlet/activation/HeaderActivationStrategy.java
+++ b/servlet/src/main/java/org/togglz/servlet/activation/HeaderActivationStrategy.java
@@ -1,0 +1,44 @@
+package org.togglz.servlet.activation;
+
+import org.togglz.core.activation.Parameter;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.spi.ActivationStrategy;
+import org.togglz.core.user.FeatureUser;
+import org.togglz.servlet.util.HttpServletRequestHolder;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+
+public class HeaderActivationStrategy implements ActivationStrategy {
+
+    static final String ID = "header";
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public String getName() {
+        return "Header";
+    }
+
+    @Override
+    public boolean isActive(FeatureState featureState, FeatureUser user) {
+        HttpServletRequest request = HttpServletRequestHolder.get();
+        if (request == null || featureState == null || featureState.getFeature() == null) {
+            return false;
+        }
+        String header = request.getHeader("X-Features");
+        if (header == null) {
+            return false;
+        }
+        String[] split = header.split(",");
+        return Arrays.stream(split).anyMatch(feature -> feature.equals(featureState.getFeature().name()));
+    }
+
+    @Override
+    public Parameter[] getParameters() {
+        return new Parameter[0];
+    }
+}

--- a/servlet/src/main/resources/META-INF/services/org.togglz.core.spi.ActivationStrategy
+++ b/servlet/src/main/resources/META-INF/services/org.togglz.core.spi.ActivationStrategy
@@ -1,3 +1,4 @@
 org.togglz.servlet.activation.ClientIpActivationStrategy
+org.togglz.servlet.activation.HeaderActivationStrategy
 org.togglz.servlet.activation.QueryParameterActivationStrategy
 org.togglz.servlet.activation.ServerNameActivationStrategy

--- a/servlet/src/test/java/org/togglz/servlet/activation/HeaderActivationStrategyTest.java
+++ b/servlet/src/test/java/org/togglz/servlet/activation/HeaderActivationStrategyTest.java
@@ -1,0 +1,94 @@
+package org.togglz.servlet.activation;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.togglz.core.Feature;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.user.FeatureUser;
+import org.togglz.core.user.SimpleFeatureUser;
+import org.togglz.servlet.util.HttpServletRequestHolder;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class HeaderActivationStrategyTest {
+
+  private FeatureUser user;
+  private FeatureState state;
+  private HttpServletRequest request;
+  private final HeaderActivationStrategy strategy = new HeaderActivationStrategy();
+
+  @BeforeEach
+  public void setUp() {
+    user = new SimpleFeatureUser("ea", false);
+    state = new FeatureState(MyFeature.FEATURE).enable();
+    request = Mockito.mock(HttpServletRequest.class);
+    HttpServletRequestHolder.bind(request);
+  }
+
+  @AfterEach
+  public void cleanup() {
+    HttpServletRequestHolder.release();
+  }
+
+  private enum MyFeature implements Feature {
+    FEATURE
+  }
+
+  @Test
+  public void shouldNotBeActiveWithANullRequestObject() {
+    HttpServletRequestHolder.release();
+
+    boolean isActive = strategy.isActive(state, user);
+
+    assertFalse(isActive);
+  }
+
+  @Test
+  public void shouldNotBeActiveWithNoHeaders() {
+    when(request.getHeader(any())).thenReturn(null);
+
+    boolean isActive = strategy.isActive(state, user);
+
+    assertFalse(isActive);
+  }
+
+  @Test
+  public void shouldNotBeActiveWhenOnlyNonMatchingParametersArePresent() {
+    Map<String, String[]> parameters = new HashMap<>();
+    parameters.put("somethingThatDoesNotMatch", (String[]) Arrays.asList("true").toArray());
+    parameters.put("somethingElse", (String[]) Arrays.asList("aValue").toArray());
+    when(request.getParameterMap()).thenReturn(parameters);
+
+    boolean isActive = strategy.isActive(state, user);
+
+    assertFalse(isActive);
+  }
+
+  @Test
+  public void shouldNotBeActiveWhenRequestHeaderDoesNotIncludeFeatureToggle() {
+    when(request.getHeader("X-Features")).thenReturn("OTHERFEATURE,ANOTHERFEATURE");
+
+    boolean isActive = strategy.isActive(state, user);
+
+    assertFalse(isActive);
+  }
+
+  @Test
+  public void shouldBeActiveWhenRequestHeaderIncludesFeatureToggle() {
+    when(request.getHeader("X-Features")).thenReturn("FEATURE,ANOTHERFEATURE");
+
+    boolean isActive = strategy.isActive(state, user);
+
+    assertTrue(isActive);
+  }
+}


### PR DESCRIPTION
closes #412 

Here I am trying to fix my own problem.
I have implemented this ActivationStrategy in kotlin and find it works exactly as I would want if using Headers as a strategy.
So I thought I would contribute this towards the togglz framework as well.
I am not that familiar with Java anymore, so I would be happy to hear any feedback.

## Changes

With this Pull Request there is another ActivationStrategy added that is parsing the requestHeader `X-Features`. 

So if you would do the call `curl -L -X GET 'http://localhost:8080/foo' -H 'X-Features: FEATURE_1,FEATURE_2' ` you would activate FEATURE_1 and FEATURE_2