### PR TITLE
Add HttpServletRequestHolderFilter

### DIFF
--- a/spring-boot/starter/src/main/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzAutoConfiguration.java
+++ b/spring-boot/starter/src/main/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
@@ -50,6 +51,7 @@ import org.togglz.spring.boot.actuate.thymeleaf.TogglzDialect;
 import org.togglz.spring.listener.TogglzApplicationContextBinderApplicationListener;
 import org.togglz.spring.security.SpringSecurityUserProvider;
 import org.togglz.spring.web.FeatureInterceptor;
+import org.togglz.spring.web.spi.HttpServletRequestHolderFilter;
 
 import java.io.IOException;
 import java.util.List;
@@ -241,6 +243,17 @@ public class TogglzAutoConfiguration {
         @ConditionalOnMissingBean
         public TogglzDialect togglzDialect() {
             return new TogglzDialect();
+        }
+    }
+
+    @Configuration
+    @ConditionalOnClass({OncePerRequestFilter.class })
+    @ConditionalOnMissingBean(HttpServletRequestHolderFilter.class)
+    protected static class RequestHolderFilterConfiguration {
+
+        @Bean
+        public HttpServletRequestHolderFilter requestHolderFilter() {
+            return new HttpServletRequestHolderFilter();
         }
     }
 }

--- a/spring-web/pom.xml
+++ b/spring-web/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -54,6 +55,23 @@
     <dependency>
       <groupId>org.togglz</groupId>
       <artifactId>togglz-test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4-legacy</artifactId>
+      <version>2.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/spring-web/src/main/java/org/togglz/spring/web/spi/HttpServletRequestHolderFilter.java
+++ b/spring-web/src/main/java/org/togglz/spring/web/spi/HttpServletRequestHolderFilter.java
@@ -1,0 +1,24 @@
+package org.togglz.spring.web.spi;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.togglz.servlet.util.HttpServletRequestHolder;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class HttpServletRequestHolderFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, FilterChain filterChain) throws ServletException, IOException {
+    try {
+      HttpServletRequestHolder.bind(httpServletRequest);
+      filterChain.doFilter(httpServletRequest, httpServletResponse);
+    }
+    finally {
+      HttpServletRequestHolder.release();
+    }
+  }
+}

--- a/spring-web/src/test/java/org/togglz/spring/web/spi/HttpServletRequestHolderFilterTest.java
+++ b/spring-web/src/test/java/org/togglz/spring/web/spi/HttpServletRequestHolderFilterTest.java
@@ -1,0 +1,77 @@
+package org.togglz.spring.web.spi;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.api.mockito.PowerMockito;
+import org.togglz.servlet.util.HttpServletRequestHolder;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+
+public class HttpServletRequestHolderFilterTest {
+
+  private HttpServletRequestHolderFilter filter;
+  private FilterChain filterChain;
+  private HttpServletRequest request;
+  private HttpServletResponse response;
+
+  @Before
+  public void setup() {
+    filter = new HttpServletRequestHolderFilter();
+    request = mock(HttpServletRequest.class);
+    filterChain = mock(FilterChain.class);
+    response = mock(HttpServletResponse.class);
+    spy(HttpServletRequestHolder.class);
+  }
+
+  @Test
+  public void shouldCallFilterChain() throws ServletException, IOException {
+    filter.doFilter(request, response, filterChain);
+    verify(filterChain, times(1)).doFilter(request, response);
+  }
+
+  @Test
+  public void shouldBindCorrectRequest() throws ServletException, IOException {
+
+    filter.doFilter(request, response, filterChain);
+    verifyStatic(HttpServletRequestHolder.class, times(1));
+    HttpServletRequestHolder.bind(any());
+  }
+
+  @Test
+  public void shouldReleaseRequest() throws ServletException, IOException {
+
+    filter.doFilter(request, response, filterChain);
+    verifyStatic(HttpServletRequestHolder.class, times(1));
+    HttpServletRequestHolder.release();
+  }
+
+  @Test
+  public void shouldReleaseRequestOnExceptionWhileBinding() {
+    PowerMockito.doThrow(new RuntimeException("boooom")).when(HttpServletRequestHolder.class);
+    HttpServletRequestHolder.bind(any());
+    assertThrows(RuntimeException.class, () -> filter.doFilter(request, response, filterChain));
+    verifyStatic(HttpServletRequestHolder.class, times(1));
+    HttpServletRequestHolder.release();
+  }
+
+  @Test
+  public void shouldReleaseRequestOnExceptionWhileFiltering() throws ServletException, IOException {
+    doThrow(new RuntimeException("boooom")).when(filterChain).doFilter(any(), any());
+    assertThrows(RuntimeException.class, () -> filter.doFilter(request, response, filterChain));
+    verifyStatic(HttpServletRequestHolder.class, times(1));
+    HttpServletRequestHolder.release();
+  }
+}


### PR DESCRIPTION
As an alternative to the [HttpServletRequestHolderListener](https://github.com/togglz/togglz/blob/master/servlet/src/main/java/org/togglz/servlet/util/HttpServletRequestHolderListener.java) here a Filter that does add the Request to the HttpServletRequestHolder.

In my opinion this would also help with the issue #237 

I implemented this for our use in kotlin and thought I offer the implementation to the community. 
Happy for feedback :)