### PR TITLE
Fix togglz-kotlin artifactId and update version

### DIFF
--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -8,7 +8,7 @@ Therefore this wrapper uses a plain enum without implementing `Feature` and prov
 
 Import dependency: 
 
-`implementation("org.togglz:kotlin:2.7.0-SNAPSHOT")`
+`implementation("org.togglz:togglz-kotlin:2.8.0")`
 
 Create an enum for your feature toggles but don't extend the Togglz-Feature interface:
 


### PR DESCRIPTION
This pull request adds the missing togglz- prefix to the artifactId and bumps the version to latest.

