### PR TITLE
Feature - Lettuce redis client integration

### DIFF
--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -23,6 +23,16 @@
 			<artifactId>jedis</artifactId>
 			<version>2.9.0</version>
 		</dependency>
+		<dependency>
+			<groupId>io.lettuce</groupId>
+			<artifactId>lettuce-core</artifactId>
+			<version>6.0.0.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-pool2</artifactId>
+			<version>2.9.0</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/redis/src/main/java/org/togglz/redis/RedisLettuceStateRepository.java
+++ b/redis/src/main/java/org/togglz/redis/RedisLettuceStateRepository.java
@@ -1,0 +1,160 @@
+package org.togglz.redis;
+
+import io.lettuce.core.api.StatefulConnection;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisHashCommands;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.togglz.core.Feature;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.repository.StateRepository;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A state repository which stores the feature state in Redis using Lettuce client.
+ * <p>
+ * The class provides a builder which can be used to configure the state repository instance
+ * (e.g. StatefulConnection pool, key prefix).
+ * </p>
+ * <p>
+ * A state repository is able to work in standalone mode (using StatefulRedisConnection) and
+ * cluster mode (using StatefulRedisClusterConnection)
+ * </p>
+ * <p>
+ * Lettuce doesn't provide default client creator (localhost as a default host, 6379 as a default port)
+ * so an exception is made when StatefulConnection pool is not set correctly
+ * </p>
+ *
+ * @author Jakub Klebek
+ */
+public class RedisLettuceStateRepository implements StateRepository {
+
+    public static final String ENABLED_FIELD = "enabled";
+    public static final String STRATEGY_FIELD = "strategy";
+    public static final String PARAMETER_PREFIX = "parameter:";
+    public static final int PARAMETER_PREFIX_LENGTH = PARAMETER_PREFIX.length();
+
+    protected final GenericObjectPool<StatefulConnection<String, String>> pool;
+    protected final String keyPrefix;
+
+    private RedisLettuceStateRepository(final Builder builder) {
+        keyPrefix = builder.keyPrefix;
+        pool = Optional.ofNullable(builder.lettucePool)
+            .orElseThrow(() -> new RedisLettuceStateRepositoryException("Missing lettuce pool configuration"));
+    }
+
+    @Override
+    public FeatureState getFeatureState(final Feature feature) {
+        try (final StatefulConnection<String, String> connection = pool.borrowObject()) {
+            final RedisHashCommands<String, String> commands = getCommands(connection);
+            final Map<String, String> redisMap = commands.hgetall(keyPrefix + feature.name());
+            if (redisMap.isEmpty()) {
+                return null;
+            }
+            final FeatureState featureState = new FeatureState(feature);
+            featureState.setEnabled(Boolean.valueOf(redisMap.get(ENABLED_FIELD)));
+            featureState.setStrategyId(redisMap.get(STRATEGY_FIELD));
+            for (final Map.Entry<String, String> entry : redisMap.entrySet()) {
+                final String key = entry.getKey();
+                if (key.startsWith(PARAMETER_PREFIX)) {
+                    featureState.setParameter(key.substring(PARAMETER_PREFIX_LENGTH), entry.getValue());
+                }
+            }
+            return featureState;
+        } catch (Exception e) {
+            throw new RedisLettuceStateRepositoryException("Error while getting feature state", e);
+        }
+    }
+
+    @Override
+    public void setFeatureState(final FeatureState featureState) {
+        try (final StatefulConnection<String, String> connection = pool.borrowObject()) {
+            final RedisHashCommands<String, String> commands = getCommands(connection);
+            final String featureKey = keyPrefix + featureState.getFeature().name();
+            commands.hset(featureKey, ENABLED_FIELD, Boolean.toString(featureState.isEnabled()));
+            final String strategyId = featureState.getStrategyId();
+            if (strategyId != null) {
+                commands.hset(featureKey, STRATEGY_FIELD, strategyId);
+            }
+            final Map<String, String> parameterMap = featureState.getParameterMap();
+            if (parameterMap != null) {
+                for (final Map.Entry<String, String> entry : parameterMap.entrySet()) {
+                    commands.hset(featureKey, PARAMETER_PREFIX + entry.getKey(), entry.getValue());
+                }
+            }
+        } catch (Exception e) {
+            throw new RedisLettuceStateRepositoryException("Error while setting feature state", e);
+        }
+    }
+
+    private RedisHashCommands<String, String> getCommands(final StatefulConnection<String, String> connection) {
+        if (connection instanceof StatefulRedisConnection) {
+            return ((StatefulRedisConnection) connection).sync();
+        }
+
+        return ((StatefulRedisClusterConnection) connection).sync();
+    }
+
+    /**
+     * Builder for a {@link RedisLettuceStateRepository}.
+     * <p>
+     * Can be used as follows:
+     * </p>
+     * <pre>
+     *      StateRepository stateRepository =
+     *         new RedisLettuceStateRepository.Builder().
+     *         lettucePool(ConnectionPoolSupport.createGenericObjectPool(
+     *              () -> RedisClient.create(RedisURI.create("localhost", 6379)).connect(),
+     *              new GenericObjectPoolConfig()))
+     *         keyPrefix("toggles:").
+     *         build();
+     * </pre>
+     */
+    public static class Builder {
+
+        private GenericObjectPool<StatefulConnection<String, String>> lettucePool;
+        private String keyPrefix = "togglz:";
+
+        /**
+         * Sets the Lettuce Pool.
+         *
+         * @param lettucePool the Lettuce Pool {@link GenericObjectPool}
+         */
+        public Builder lettucePool(final GenericObjectPool<StatefulConnection<String, String>> lettucePool) {
+            this.lettucePool = lettucePool;
+            return this;
+        }
+
+        /**
+         * Sets the Redis key prefix to be used when getting or setting the state of the features.
+         *
+         * @param keyPrefix the key prefix to be used in Redis
+         */
+        public Builder keyPrefix(final String keyPrefix) {
+            this.keyPrefix = keyPrefix;
+            return this;
+        }
+
+        /**
+         * Creates a new {@link RedisLettuceStateRepository} using the current settings.
+         */
+        public RedisLettuceStateRepository build() {
+            return new RedisLettuceStateRepository(this);
+        }
+
+    }
+
+    private static class RedisLettuceStateRepositoryException extends RuntimeException {
+
+        public RedisLettuceStateRepositoryException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        public RedisLettuceStateRepositoryException(String message) {
+            super(message);
+        }
+    }
+
+}

--- a/redis/src/test/java/org/togglz/redis/RedisLettuceStateRepositoryTest.java
+++ b/redis/src/test/java/org/togglz/redis/RedisLettuceStateRepositoryTest.java
@@ -1,0 +1,120 @@
+package org.togglz.redis;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulConnection;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.support.ConnectionPoolSupport;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.togglz.core.Feature;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.repository.StateRepository;
+import org.togglz.core.util.NamedFeature;
+import redis.embedded.RedisServer;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RedisLettuceStateRepositoryTest {
+
+    private RedisServer redisServer;
+
+    @BeforeEach
+    public void before() throws IOException {
+        redisServer = new RedisServer();
+        redisServer.start();
+    }
+
+    @AfterEach
+    public void after() {
+        redisServer.stop();
+    }
+
+    @Test
+    public void testGetFeatureStateNotExisting() {
+        final StateRepository stateRepository = aRedisStateRepository();
+        final Feature feature = new NamedFeature("A_FEATURE");
+
+        final FeatureState storedFeatureState = stateRepository.getFeatureState(feature);
+
+        assertNull(storedFeatureState);
+    }
+
+    @Test
+    public void testSetFeatureStateWithStrategyAndParameter() {
+        final StateRepository stateRepository = aRedisStateRepository();
+        final Feature feature = new NamedFeature("A_FEATURE");
+        final FeatureState featureState = new FeatureState(feature, true);
+        featureState.setStrategyId("TIT_FOR_TAT");
+        featureState.setParameter("MEANING_OF_LIFE", "42");
+
+        stateRepository.setFeatureState(featureState);
+        final FeatureState storedFeatureState = stateRepository.getFeatureState(feature);
+
+        assertTrue(EqualsBuilder.reflectionEquals(featureState, storedFeatureState, true));
+    }
+
+    @Test
+    public void testSetFeatureStateExisting() {
+        final StateRepository stateRepository = aRedisStateRepository();
+        final Feature feature = new NamedFeature("A_FEATURE");
+        final FeatureState featureState = new FeatureState(feature, true);
+
+        stateRepository.setFeatureState(featureState);
+        FeatureState storedFeatureState = stateRepository.getFeatureState(feature);
+
+        assertTrue(storedFeatureState.isEnabled());
+        assertTrue(EqualsBuilder.reflectionEquals(featureState, storedFeatureState, true));
+
+        featureState.setEnabled(false);
+        stateRepository.setFeatureState(featureState);
+        storedFeatureState = stateRepository.getFeatureState(feature);
+
+        assertFalse(storedFeatureState.isEnabled());
+        assertTrue(EqualsBuilder.reflectionEquals(featureState, storedFeatureState, true));
+    }
+
+    @Test
+    public void testFormatOfExistingFeatureState() throws Exception {
+
+        // set contents in Redis directly, without using the RedisStateRepository API
+        final GenericObjectPool<StatefulConnection<String, String>> lettucePool = createPool();
+        try (final StatefulRedisConnection<String, String> connection = (StatefulRedisConnection<String, String>) lettucePool.borrowObject()) {
+            final String key = "feature-toggles:A_FEATURE";
+            connection.sync().hset(key, "enabled", "true");
+            connection.sync().hset(key, "strategy", "TIT_FOR_TAT");
+            connection.sync().hset(key, "parameter:MEANING_OF_LIFE", "42");
+        }
+
+        final Feature feature = new NamedFeature("A_FEATURE");
+        final FeatureState expectedFeatureState = new FeatureState(feature, true);
+        expectedFeatureState.setStrategyId("TIT_FOR_TAT");
+        expectedFeatureState.setParameter("MEANING_OF_LIFE", "42");
+
+        final FeatureState storedFeatureState = aRedisStateRepository().getFeatureState(feature);
+
+        assertTrue(EqualsBuilder.reflectionEquals(expectedFeatureState, storedFeatureState, true));
+    }
+
+    private RedisLettuceStateRepository aRedisStateRepository() {
+        return new RedisLettuceStateRepository.Builder()
+            .keyPrefix("feature-toggles:")
+            .lettucePool(createPool())
+            .build();
+    }
+
+    private GenericObjectPool<StatefulConnection<String, String>> createPool() {
+        RedisClient client = RedisClient.create(RedisURI.create("localhost", 6379));
+
+        return ConnectionPoolSupport
+            .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig());
+    }
+ }


### PR DESCRIPTION
In my project there is a need to use togglz features and integrate it with our redis to store data in cache (we don't have any dbs). We use Lettuce as a redis java client and I have to write Togglz StateRepository myself to work with it. 
Moreover, we use standalone and cluster Redis modes depending on the environment so my implementation of StateRepository is able to work with both of them.