### PR TITLE
No restriction of @FeaturesAreActive for enum-feature-classes

### DIFF
--- a/shiro/pom.xml
+++ b/shiro/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/spring-web/src/main/java/org/togglz/spring/web/FeaturesAreActive.java
+++ b/spring-web/src/main/java/org/togglz/spring/web/FeaturesAreActive.java
@@ -1,31 +1,28 @@
 package org.togglz.spring.web;
 
 import org.springframework.stereotype.Controller;
-import org.togglz.core.Feature;
 
 import java.lang.annotation.*;
 
 /**
  * Annotate a {@link Controller} or a controller method to only activate it when
- * all the features given in the {@link #features()} attribute of the given {@link #featureClass()} are active.
+ * all the features given in the {@link #features()} attribute are active.
  * <p>
  * If the features are not activated, a response with the status code given by the {@link #responseStatus()}
  * attribute is generated (404 by default).
- * <p>
- * The {@link Feature} implementation given in the {@link #featureClass()} attribute needs to be an enum.
- * 
+ *
  * <pre>
- * &#64;Controller
- * &#64;RequestMapping("/new-feature")
- * &#64;FeaturesAreActive(featureClass=MyFeatures.class, features="NEW_FEATURE")
+ * @Controller
+ * @RequestMapping("/new-feature")
+ * @FeaturesAreActive(features="NEW_FEATURE")
  * public class MyNewFeature {
- *     &#64;RequestMapping(method = RequestMethod.GET)
+ *     @RequestMapping(method = RequestMethod.GET)
  *     public String newFeature() {
  *         return ....;
  *     }
- *     
- *     &#64;FeaturesAreActive(featureClass=MyFeatures.class, features="NEW_SECURE_FEATURE", responseStatus=403)
- *     &#64;RequestMapping(value="/secure", method = RequestMethod.GET)
+ *
+ *     @FeaturesAreActive(features="NEW_SECURE_FEATURE", responseStatus=403)
+ *     @RequestMapping(value="/secure", method = RequestMethod.GET)
  *     public String newSecureFeature() {
  *         return ....;
  *     }
@@ -34,12 +31,14 @@ import java.lang.annotation.*;
  * The {@link FeatureInterceptor} needs to be registered in Spring MVC for this to work. This is automatically
  * done by the TogglzAutoConfiguration config which is loaded if @EnableAutoConfiguration
  * is used in your project.
+ *
+ * @author ractive
+ * @author m-schroeer
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Documented
 public @interface FeaturesAreActive {
-	String[] features();
-	Class<? extends Feature> featureClass();
-	int responseStatus() default 404;
+    String[] features();
+    int responseStatus() default 404;
 }


### PR DESCRIPTION
Extends the usage of the great feature introduced by @ractive (https://github.com/togglz/togglz/pull/166#issue-74804051).

Since the feature names had to be present as string literals (even before this change) the usage of enum-feature-classes is an unnecessary limitation of @FeaturesAreActive.

To 'fix' this limitation these changes do the following:
- FeaturesAreActive.java:
    - remove annotation  field featureClass()
- FeatureInterceptor.java:
    - remove all enum-related code
    - the check is done by:
        1. exception if not all features-string of annotation are actual features (independently from 'active' status)
        2. check if all features of annotation are active (by FeatureManager)
        3. decide if error response or not

---------
This means you can do the following:
```java
 @Controller
 @RequestMapping("/new-feature")
 @FeaturesAreActive(features="NEW_FEATURE")
 public class MyNewFeature {
     @RequestMapping(method = RequestMethod.GET)
     public String newFeature() {
         return ....;
     }

     @FeaturesAreActive(features="NEW_SECURE_FEATURE", responseStatus=403)
     @RequestMapping(value="/secure", method = RequestMethod.GET)
     public String newSecureFeature() {
         return ....;
     }
 }
```
 
Note the missing `featureClass=MyFeatures.class` in `@FeaturesAreActive(...)`.