### PR TITLE
Re-add 'spring-boot-configuration-processor'

### DIFF
--- a/spring-boot/starter/pom.xml
+++ b/spring-boot/starter/pom.xml
@@ -44,6 +44,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf</artifactId>
       <version>3.0.11.RELEASE</version>


### PR DESCRIPTION
Re-add 'spring-boot-configuration-processor' to 'togglz-spring-boot-starter'.

This dependency was removed with former togglz/spring-boot/autoconfigure project during re-structuring of spring-based-projects after 2.6.1.Final.
It is necessary for the IDE binding between files with `@ConfigurationProperties` and `application.properties` file (e. g. [TogglzProperties.java](https://github.com/togglz/togglz/blob/master/spring-boot/starter/src/main/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzProperties.java) ) and therefor quite useful (e. g. auto-completion in `application.properties`)

See: https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-configuration-metadata.html#configuration-metadata-annotation-processor