### PR TITLE
update spring and spring-boot version (5.3.2 and 2.4.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <!-- Wildfly version used for integration tests -->
     <wildfly.version>8.2.1.Final</wildfly.version>
 
-    <spring.version>5.2.7.RELEASE</spring.version>
+    <spring.version>5.3.2</spring.version>
     <junit.version>5.7.0</junit.version>
   </properties>
 

--- a/spring-boot/starter/pom.xml
+++ b/spring-boot/starter/pom.xml
@@ -72,12 +72,24 @@
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/spring-boot/starter/pom.xml
+++ b/spring-boot/starter/pom.xml
@@ -13,7 +13,7 @@
   <description>Togglz - Spring Boot Starter</description>
 
   <properties>
-    <spring-boot.version>2.3.3.RELEASE</spring-boot.version>
+    <spring-boot.version>2.4.1</spring-boot.version>
   </properties>
 
   <dependencyManagement>

--- a/spring-boot/starter/src/main/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzAutoConfiguration.java
+++ b/spring-boot/starter/src/main/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzAutoConfiguration.java
@@ -32,7 +32,7 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.togglz.console.TogglzConsoleServlet;
 import org.togglz.core.Feature;
 import org.togglz.core.activation.ActivationStrategyProvider;
@@ -227,7 +227,7 @@ public class TogglzAutoConfiguration {
 
     @Configuration
     @ConditionalOnWebApplication
-    @ConditionalOnClass(HandlerInterceptorAdapter.class)
+    @ConditionalOnClass(HandlerInterceptor.class)
     @ConditionalOnProperty(prefix = "togglz.web", name = "register-feature-interceptor", havingValue = "true")
     protected static class TogglzFeatureInterceptorConfiguration implements WebMvcConfigurer {
         @Override

--- a/spring-boot/starter/src/test/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzManagementContextConfigurationTest.java
+++ b/spring-boot/starter/src/test/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzManagementContextConfigurationTest.java
@@ -17,7 +17,7 @@
 package org.togglz.spring.boot.actuate.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Collection;
 


### PR DESCRIPTION
Updated spring versions.

Additionally replaced `HandlerInterceptorAdapter` that was deprecated since `5.3`.