### PR TITLE
Added CSRF protection to the togglz console

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -77,5 +77,11 @@
       <version>6.0.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <version>4.4</version>
+    </dependency>
+
   </dependencies>
 </project>

--- a/console/src/main/java/org/togglz/console/security/TogglzCSRFTokenCache.java
+++ b/console/src/main/java/org/togglz/console/security/TogglzCSRFTokenCache.java
@@ -1,0 +1,32 @@
+package org.togglz.console.security;
+
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.collections4.map.PassiveExpiringMap;
+import org.togglz.servlet.spi.CSRFToken;
+
+public class TogglzCSRFTokenCache {
+
+	private static final PassiveExpiringMap<String, CSRFToken> expiringMap;
+	private static final Object lock = new Object();
+	static {
+		PassiveExpiringMap.ConstantTimeToLiveExpirationPolicy<String, CSRFToken>
+				expirationPolicy = new PassiveExpiringMap.ConstantTimeToLiveExpirationPolicy<>(
+				10, TimeUnit.MINUTES);
+		expiringMap = new PassiveExpiringMap<>(expirationPolicy, new HashMap<>());
+	}
+
+	public static void cacheToken(CSRFToken token) {
+		synchronized (lock) {
+			expiringMap.put(token.getValue(), token);
+		}
+	}
+
+	public static boolean isTokenInCache(CSRFToken token) {
+		synchronized (lock) {
+			return expiringMap.containsKey(token.getValue());
+		}
+	}
+	
+}

--- a/console/src/main/java/org/togglz/console/security/TogglzCSRFTokenProvider.java
+++ b/console/src/main/java/org/togglz/console/security/TogglzCSRFTokenProvider.java
@@ -1,0 +1,25 @@
+package org.togglz.console.security;
+
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.togglz.servlet.spi.CSRFToken;
+import org.togglz.servlet.spi.CSRFTokenProvider;
+
+import static org.togglz.console.security.TogglzCSRFTokenValidator.CSRF_TOKEN_NAME;
+
+public class TogglzCSRFTokenProvider implements CSRFTokenProvider {
+
+	@Override
+	public CSRFToken getToken(HttpServletRequest request) {
+		CSRFToken token;
+		if (request.getAttribute(CSRF_TOKEN_NAME) == null) {
+			token = new CSRFToken(CSRF_TOKEN_NAME, UUID.randomUUID().toString());
+			TogglzCSRFTokenCache.cacheToken(token);
+		} else {
+			token = new CSRFToken(CSRF_TOKEN_NAME, request.getAttribute(CSRF_TOKEN_NAME).toString());
+		}
+		return token;
+	}
+}

--- a/console/src/main/java/org/togglz/console/security/TogglzCSRFTokenValidator.java
+++ b/console/src/main/java/org/togglz/console/security/TogglzCSRFTokenValidator.java
@@ -1,0 +1,22 @@
+package org.togglz.console.security;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.togglz.servlet.spi.CSRFToken;
+import org.togglz.servlet.spi.CSRFTokenValidator;
+
+public class TogglzCSRFTokenValidator implements CSRFTokenValidator {
+
+
+	public static final String CSRF_TOKEN_NAME = "togglz_csrf";
+
+	@Override
+	public boolean isTokenValid(HttpServletRequest request) {
+		String token = request.getParameter(CSRF_TOKEN_NAME);
+		if(token==null) {
+			return false;
+		} else {
+			return TogglzCSRFTokenCache.isTokenInCache(new CSRFToken(CSRF_TOKEN_NAME,token));
+		}
+	}
+}

--- a/console/src/main/resources/META-INF/services/org.togglz.servlet.spi.CSRFTokenProvider
+++ b/console/src/main/resources/META-INF/services/org.togglz.servlet.spi.CSRFTokenProvider
@@ -1,0 +1,1 @@
+org.togglz.console.security.TogglzCSRFTokenProvider

--- a/console/src/main/resources/META-INF/services/org.togglz.servlet.spi.CSRFTokenValidator
+++ b/console/src/main/resources/META-INF/services/org.togglz.servlet.spi.CSRFTokenValidator
@@ -1,0 +1,1 @@
+org.togglz.console.security.TogglzCSRFTokenValidator

--- a/console/src/main/resources/org/togglz/console/error.html
+++ b/console/src/main/resources/org/togglz/console/error.html
@@ -1,0 +1,4 @@
+<div style="text-align: center;">
+    <h1>ERROR</h1>
+    <h1><small>Invalid CSRF Token, please refresh browser from the main Togglz page.</small></h1>
+</div>

--- a/console/src/main/resources/org/togglz/console/index.html
+++ b/console/src/main/resources/org/togglz/console/index.html
@@ -67,8 +67,7 @@
                 ${end}
               </td>
               <td class="feature-actions">
-                <a class="btn btn-sm btn-default" href="edit?f=${feature.name}" title="Edit ${feature.label} feature">
-                  <span class="glyphicon glyphicon-cog text-muted"></span>
+                  <a class="btn btn-sm btn-default" href="edit?f=${feature.name}${foreach tokens token}${if token.name = "togglz_csrf"}&${token.name}=${token.value}${end}${end}" title="Edit ${feature.label} feature">                  <span class="glyphicon glyphicon-cog text-muted"></span>
                 </a>
               </td>
             </tr>

--- a/servlet/src/main/java/org/togglz/servlet/spi/CSRFTokenValidator.java
+++ b/servlet/src/main/java/org/togglz/servlet/spi/CSRFTokenValidator.java
@@ -1,0 +1,9 @@
+package org.togglz.servlet.spi;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface CSRFTokenValidator {
+
+
+	boolean isTokenValid(HttpServletRequest request);
+}


### PR DESCRIPTION
Added CSRF protection to the togglz console via a CSRF token passed between the server and the clinet. This remediates the vulnerabilty CVE-2020-28191 by blocking CSRF attacks as the attcker will not be able to guess the CSRF token value.

This has been implemented with either the session timeout of the application the togglz console is embedded in. Or if no user session is available it defaults to a 10 minute timeout for the CSRF token.
This CSRF token does not interfere with either OWASP's CSRFGuard or Spring-Security's CSRF protection if they are used within the application.