### PR TITLE
Issue #492 httpstatus

### DIFF
--- a/spring-web/src/main/java/org/togglz/spring/web/FeatureInterceptor.java
+++ b/spring-web/src/main/java/org/togglz/spring/web/FeatureInterceptor.java
@@ -3,7 +3,7 @@ package org.togglz.spring.web;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.method.HandlerMethod;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.togglz.core.Feature;
 import org.togglz.core.context.FeatureContext;
 import org.togglz.core.manager.FeatureManager;
@@ -27,7 +27,8 @@ import javax.servlet.http.HttpServletResponse;
  * @author ractive
  * @author m-schroeer
  */
-public class FeatureInterceptor extends HandlerInterceptorAdapter {
+public class FeatureInterceptor implements HandlerInterceptor {
+
     /**
      * Used to store annotations in a ConcurrentHashMap which does not allow storing {@code null} values.
      * 
@@ -91,7 +92,7 @@ public class FeatureInterceptor extends HandlerInterceptorAdapter {
                 }
             }
         }
-        return super.preHandle(request, response, handler);
+        return HandlerInterceptor.super.preHandle(request, response, handler);
     }
 
     // TODO: When deprecated field FeaturesAreActive#responseStatus is removed, this method could be removed as well and

--- a/spring-web/src/main/java/org/togglz/spring/web/FeatureInterceptor.java
+++ b/spring-web/src/main/java/org/togglz/spring/web/FeatureInterceptor.java
@@ -8,18 +8,17 @@ import org.togglz.core.Feature;
 import org.togglz.core.context.FeatureContext;
 import org.togglz.core.manager.FeatureManager;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.lang.annotation.Annotation;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 /**
  * This interceptor checks if a controller or controller method is annotated with the
- * {@link FeaturesAreActive} annotation to determine if a controller should be 
+ * {@link FeaturesAreActive} annotation to determine if a controller should be
  * activated or not.
  * <p>
  * Set the togglz.web.register-feature-interceptor to {@code true} to activate this interceptor.
@@ -31,55 +30,56 @@ public class FeatureInterceptor implements HandlerInterceptor {
 
     /**
      * Used to store annotations in a ConcurrentHashMap which does not allow storing {@code null} values.
-     * 
+     *
      * @param <A> annotation type
      */
     private static final class AnnotationHolder<A extends Annotation> {
+
         private final A annotation;
-        
-        public AnnotationHolder(A annotation) {
+
+        public AnnotationHolder(final A annotation) {
             this.annotation = annotation;
         }
-        
+
         public A getAnnotation() {
-            return annotation;
+            return this.annotation;
         }
-        
+
         public boolean hasAnnotation() {
-            return annotation != null;
+            return this.annotation != null;
         }
     }
 
     /**
      * Caches the annotations on the {@link HandlerMethod}s to avoid expensive reflection calls for every request.
      */
-    private ConcurrentHashMap<HandlerMethod, AnnotationHolder<FeaturesAreActive>> annotations = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<HandlerMethod, AnnotationHolder<FeaturesAreActive>> annotations = new ConcurrentHashMap<>();
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
         if (handler instanceof HandlerMethod) {
-            HandlerMethod handlerMethod = (HandlerMethod) handler;
-            AnnotationHolder<FeaturesAreActive> annotationHolder = annotations.get(handlerMethod);
+            final HandlerMethod handlerMethod = (HandlerMethod) handler;
+            AnnotationHolder<FeaturesAreActive> annotationHolder = this.annotations.get(handlerMethod);
             if (annotationHolder == null) {
-                FeaturesAreActive foundAnnotation = handlerAnnotation(handlerMethod, FeaturesAreActive.class);
-                annotations.putIfAbsent(handlerMethod, new AnnotationHolder<FeaturesAreActive>(foundAnnotation));
-                annotationHolder = annotations.get(handlerMethod);
+                final FeaturesAreActive foundAnnotation = handlerAnnotation(handlerMethod, FeaturesAreActive.class);
+                this.annotations.putIfAbsent(handlerMethod, new AnnotationHolder<>(foundAnnotation));
+                annotationHolder = this.annotations.get(handlerMethod);
             }
-            
-            if (annotationHolder.hasAnnotation()) {
-                FeaturesAreActive featuresAreActiveAnnotation = annotationHolder.getAnnotation();
 
-                Set<String> annotationFeatureNames = Stream.of(
+            if (annotationHolder.hasAnnotation()) {
+                final FeaturesAreActive featuresAreActiveAnnotation = annotationHolder.getAnnotation();
+
+                final Set<String> annotationFeatureNames = Stream.of(
                         featuresAreActiveAnnotation.features())
                         .collect(Collectors.toSet());
 
-                FeatureManager featureManager = FeatureContext.getFeatureManager();
+                final FeatureManager featureManager = FeatureContext.getFeatureManager();
 
                 if (!getFeatureNames(featureManager).containsAll(annotationFeatureNames)) {
                     throw new IllegalArgumentException("At least one given feature of '" + annotationFeatureNames + "' is not a feature!");
                 }
 
-                boolean allFeaturesOfAnnotationMatch = featureManager.getFeatures()
+                final boolean allFeaturesOfAnnotationMatch = featureManager.getFeatures()
                         .stream()
                         // reduce to features of annotation
                         .filter(feature -> annotationFeatureNames.contains(feature.name()))
@@ -118,14 +118,14 @@ public class FeatureInterceptor implements HandlerInterceptor {
         }
     }
 
-    protected static <A extends Annotation> A handlerAnnotation(HandlerMethod handlerMethod, Class<A> annotationClass) {
+    protected static <A extends Annotation> A handlerAnnotation(final HandlerMethod handlerMethod, final Class<A> annotationClass) {
         A annotation = handlerMethod.getMethodAnnotation(annotationClass);
         if (annotation == null) {
             annotation = AnnotationUtils.findAnnotation(handlerMethod.getBeanType(), annotationClass);
         }
         return annotation;
     }
-    
+
     protected static Set<String> getFeatureNames(final FeatureManager featureManager) {
         return featureManager.getFeatures().stream()
                 .map(Feature::name)

--- a/spring-web/src/main/java/org/togglz/spring/web/FeaturesAreActive.java
+++ b/spring-web/src/main/java/org/togglz/spring/web/FeaturesAreActive.java
@@ -1,5 +1,6 @@
 package org.togglz.spring.web;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 
 import java.lang.annotation.*;
@@ -8,8 +9,8 @@ import java.lang.annotation.*;
  * Annotate a {@link Controller} or a controller method to only activate it when
  * all the features given in the {@link #features()} attribute are active.
  * <p>
- * If the features are not activated, a response with the status code given by the {@link #responseStatus()}
- * attribute is generated (404 by default).
+ * If the features are not activated, a response with the status code given by the {@link #errorResponseStatus()}
+ * attribute is generated (HttpStatus.NOT_FOUND (404) by default).
  *
  * <pre>
  * @Controller
@@ -21,7 +22,7 @@ import java.lang.annotation.*;
  *         return ....;
  *     }
  *
- *     @FeaturesAreActive(features="NEW_SECURE_FEATURE", responseStatus=403)
+ *     @FeaturesAreActive(features="NEW_SECURE_FEATURE", errorResponseStatus = HttpStatus.FORBIDDEN)
  *     @RequestMapping(value="/secure", method = RequestMethod.GET)
  *     public String newSecureFeature() {
  *         return ....;
@@ -39,6 +40,16 @@ import java.lang.annotation.*;
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Documented
 public @interface FeaturesAreActive {
+
+    HttpStatus DEFAULT_ERROR_RESPONSE_STATUS = HttpStatus.NOT_FOUND;
+
     String[] features();
+
+    /**
+     * @deprecated use {{@link #errorResponseStatus()} instead}.
+     */
+    @Deprecated
     int responseStatus() default 404;
+
+    HttpStatus errorResponseStatus() default HttpStatus.NOT_FOUND;
 }

--- a/spring-web/src/test/java/org/togglz/spring/web/FeatureInterceptorTest.java
+++ b/spring-web/src/test/java/org/togglz/spring/web/FeatureInterceptorTest.java
@@ -26,8 +26,8 @@ import org.togglz.core.repository.mem.InMemoryStateRepository;
  */
 public class FeatureInterceptorTest {
 
-    private static final int METHOD_FEATURE_TWO_RESPONSE_STATUS = 302;
-    
+    private static final HttpStatus DEFAULT_ERROR_RESPONSE_STATUS = FeaturesAreActive.DEFAULT_ERROR_RESPONSE_STATUS;
+
     private FeatureManager manager;
     private InMemoryStateRepository repository;
 
@@ -67,12 +67,24 @@ public class FeatureInterceptorTest {
         
         @FeaturesAreActive(features = "METHOD_FEATURE")
         public void methodFeature() { }
-        
-        @FeaturesAreActive(features = {"METHOD_FEATURE", "METHOD_FEATURE_TWO"}, responseStatus = METHOD_FEATURE_TWO_RESPONSE_STATUS)
+
+        @FeaturesAreActive(features = {"METHOD_FEATURE", "METHOD_FEATURE_TWO"}, errorResponseStatus = HttpStatus.FOUND)
         public void methodFeatureTwo() { }
         
         @FeaturesAreActive(features = {"METHOD_FEATURE", "NO_FEATURE", "METHOD_FEATURE_TWO"})
         public void methodFeatureAtLeastOneIsNoFeature() { }
+
+        @FeaturesAreActive(features = "METHOD_FEATURE", responseStatus = 402)
+        public void methodFeatureDeprecatedResponseStatusNotDefault() { }
+
+        @FeaturesAreActive(features = "METHOD_FEATURE", errorResponseStatus = HttpStatus.FORBIDDEN)
+        public void methodFeatureErrorResponseStatusNotDefault() { }
+
+        @FeaturesAreActive(features = "METHOD_FEATURE", responseStatus = 403, errorResponseStatus = HttpStatus.FORBIDDEN)
+        public void methodFeatureDeprecatedResponseAndErrorResponseEqualValue() { }
+
+        @FeaturesAreActive(features = "METHOD_FEATURE", responseStatus = 402, errorResponseStatus = HttpStatus.FORBIDDEN)
+        public void methodFeatureDeprecatedResponseAndErrorResponseDifferentValues() { }
     }
 
     private static class NonAnnotatedTestController {
@@ -95,49 +107,71 @@ public class FeatureInterceptorTest {
 
     @Test
     public void preHandle_ClassFeature_Inactive() throws Exception {
-        assertPrehandle("classFeature", false, HttpStatus.NOT_FOUND.value());
+        assertPrehandle("classFeature", false, DEFAULT_ERROR_RESPONSE_STATUS);
     }
 
     @Test
     public void preHandle_ClassFeature_Active() throws Exception {
         enableFeature(TestFeatures.CLASS_FEATURE);
-        assertPrehandle("classFeature", true, HttpStatus.OK.value());
+        assertPrehandle("classFeature", true, HttpStatus.OK);
     }
 
     @Test
     public void preHandle_MethodFeature_Inactive() throws Exception {
-        assertPrehandle("methodFeature", false, HttpStatus.NOT_FOUND.value());
+        assertPrehandle("methodFeature", false, DEFAULT_ERROR_RESPONSE_STATUS);
     }
     
     @Test
     public void preHandle_MethodFeature_Active() throws Exception {
         enableFeature(TestFeatures.METHOD_FEATURE);
-        assertPrehandle("methodFeature", true, HttpStatus.OK.value());
+        assertPrehandle("methodFeature", true, HttpStatus.OK);
     }
 
     @Test
     public void preHandle_MethodFeatureTwo_Inactive() throws Exception {
-        assertPrehandle("methodFeatureTwo", false, METHOD_FEATURE_TWO_RESPONSE_STATUS);
+        assertPrehandle("methodFeatureTwo", false, HttpStatus.FOUND);
     }
     
     @Test
     public void preHandle_MethodFeatureTwo_OnlyOneActive() throws Exception {
         enableFeature(TestFeatures.METHOD_FEATURE);
-        assertPrehandle("methodFeatureTwo", false, METHOD_FEATURE_TWO_RESPONSE_STATUS);
+        assertPrehandle("methodFeatureTwo", false, HttpStatus.FOUND);
     }
 
     @Test
     public void preHandle_MethodFeatureTwo_AllActive() throws Exception {
         enableFeature(TestFeatures.METHOD_FEATURE);
         enableFeature(TestFeatures.METHOD_FEATURE_TWO);
-        assertPrehandle("methodFeatureTwo", true, HttpStatus.OK.value());
+        assertPrehandle("methodFeatureTwo", true, HttpStatus.OK);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void preHandle_MethodFeatureAtLeastOneIsNoFeature_AllActualFeaturesActive() throws Exception {
         enableFeature(TestFeatures.METHOD_FEATURE);
         enableFeature(TestFeatures.METHOD_FEATURE_TWO);
-        assertPrehandle("methodFeatureAtLeastOneIsNoFeature", false, HttpStatus.NOT_FOUND.value());
+        assertPrehandle("methodFeatureAtLeastOneIsNoFeature", false, DEFAULT_ERROR_RESPONSE_STATUS);
+    }
+
+    @Test
+    public void preHandle_MethodFeature_preferDeprecatedResponseIfNotDefault() throws Exception {
+        assertPrehandle("methodFeatureDeprecatedResponseStatusNotDefault", false, HttpStatus.valueOf(402));
+    }
+
+    @Test
+    public void preHandle_MethodFeature_preferErrorResponseStatusIfNotDefault() throws Exception {
+        assertPrehandle("methodFeatureErrorResponseStatusNotDefault", false, HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    public void preHandle_MethodFeature_useAnyIfDeprecatedResponseStatusAndErrorResponseStatusAreEqual() throws Exception {
+        assertPrehandle("methodFeatureDeprecatedResponseAndErrorResponseEqualValue", false, HttpStatus.FORBIDDEN);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void preHandle_MethodFeature_throwISEIfDeprecatedResponseStatusAndErrorResponseStatusAreDifferent() throws Exception {
+        // just to compile. the actual value is irrelevant, as there should be an exception because of ambiguous configuration
+        final HttpStatus any = HttpStatus.valueOf(200);
+        assertPrehandle("methodFeatureDeprecatedResponseAndErrorResponseDifferentValues", false, any);
     }
 
     @Test
@@ -146,7 +180,7 @@ public class FeatureInterceptorTest {
         HandlerMethod handler = new HandlerMethod(controller, "classFeature");
         FeaturesAreActive annotation = FeatureInterceptor.handlerAnnotation(handler, FeaturesAreActive.class);
         assertNotNull(annotation);
-        assertEquals(HttpStatus.NOT_FOUND.value(), annotation.responseStatus());
+        assertEquals(DEFAULT_ERROR_RESPONSE_STATUS, annotation.errorResponseStatus());
         assertThat(annotation.features()).containsExactly("CLASS_FEATURE");
     }
 
@@ -156,7 +190,7 @@ public class FeatureInterceptorTest {
         HandlerMethod handler = new HandlerMethod(controller, "methodFeatureTwo");
         FeaturesAreActive annotation = FeatureInterceptor.handlerAnnotation(handler, FeaturesAreActive.class);
         assertNotNull(annotation);
-        assertEquals(302, annotation.responseStatus());
+        assertEquals(HttpStatus.FOUND, annotation.errorResponseStatus());
         assertThat(annotation.features()).containsExactly("METHOD_FEATURE", "METHOD_FEATURE_TWO");
     }
 
@@ -165,7 +199,7 @@ public class FeatureInterceptorTest {
         assertTrue(manager.isActive(feature));
     }
 
-    private void assertPrehandle(String methodName, boolean expectedReturnValue, int expectedStatusCode) throws NoSuchMethodException, Exception {
+    private void assertPrehandle(String methodName, boolean expectedReturnValue, HttpStatus expectedStatus) throws NoSuchMethodException, Exception {
         FeatureInterceptor featureInterceptor = new FeatureInterceptor();
         
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -174,7 +208,7 @@ public class FeatureInterceptorTest {
         HandlerMethod handler = new HandlerMethod(controller, methodName);
         
         assertEquals(expectedReturnValue, featureInterceptor.preHandle(request, response, handler));
-        assertEquals(expectedStatusCode, response.getStatus());
+        assertEquals(expectedStatus.value(), response.getStatus());
     }
 }
 

--- a/spring-web/src/test/java/org/togglz/spring/web/FeatureInterceptorTest.java
+++ b/spring-web/src/test/java/org/togglz/spring/web/FeatureInterceptorTest.java
@@ -1,10 +1,5 @@
 package org.togglz.spring.web;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,6 +15,11 @@ import org.togglz.core.manager.FeatureManagerBuilder;
 import org.togglz.core.repository.FeatureState;
 import org.togglz.core.repository.mem.InMemoryStateRepository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 /**
  * @author ractive
  * @author m-schroeer
@@ -31,27 +31,21 @@ public class FeatureInterceptorTest {
     private FeatureManager manager;
     private InMemoryStateRepository repository;
 
-    private static enum TestFeatures implements Feature {
+    private enum TestFeatures implements Feature {
         CLASS_FEATURE,
         METHOD_FEATURE,
         METHOD_FEATURE_TWO
     }
-    
-    private static class NoEnumFeature implements Feature {
-        @Override
-        public String name() {
-            return "johndoe";
-        }}
 
     @Before
     public void before() {
-        repository = new InMemoryStateRepository();
-        manager = new FeatureManagerBuilder()
-            .featureEnum(TestFeatures.class)
-            .stateRepository(repository)
-            .build();
-        
-        ThreadLocalFeatureManagerProvider.bind(manager);
+        this.repository = new InMemoryStateRepository();
+        this.manager = new FeatureManagerBuilder()
+                .featureEnum(TestFeatures.class)
+                .stateRepository(this.repository)
+                .build();
+
+        ThreadLocalFeatureManagerProvider.bind(this.manager);
     }
 
     @After
@@ -62,123 +56,134 @@ public class FeatureInterceptorTest {
 
     @FeaturesAreActive(features = "CLASS_FEATURE")
     private static class TestController {
+
         @SuppressWarnings("unused")
-        public void classFeature() { }
-        
+        public void classFeature() {
+        }
+
         @FeaturesAreActive(features = "METHOD_FEATURE")
-        public void methodFeature() { }
+        public void methodFeature() {
+        }
 
         @FeaturesAreActive(features = {"METHOD_FEATURE", "METHOD_FEATURE_TWO"}, errorResponseStatus = HttpStatus.FOUND)
-        public void methodFeatureTwo() { }
-        
+        public void methodFeatureTwo() {
+        }
+
         @FeaturesAreActive(features = {"METHOD_FEATURE", "NO_FEATURE", "METHOD_FEATURE_TWO"})
-        public void methodFeatureAtLeastOneIsNoFeature() { }
+        public void methodFeatureAtLeastOneIsNoFeature() {
+        }
 
         @FeaturesAreActive(features = "METHOD_FEATURE", responseStatus = 402)
-        public void methodFeatureDeprecatedResponseStatusNotDefault() { }
+        public void methodFeatureDeprecatedResponseStatusNotDefault() {
+        }
 
         @FeaturesAreActive(features = "METHOD_FEATURE", errorResponseStatus = HttpStatus.FORBIDDEN)
-        public void methodFeatureErrorResponseStatusNotDefault() { }
+        public void methodFeatureErrorResponseStatusNotDefault() {
+        }
 
         @FeaturesAreActive(features = "METHOD_FEATURE", responseStatus = 403, errorResponseStatus = HttpStatus.FORBIDDEN)
-        public void methodFeatureDeprecatedResponseAndErrorResponseEqualValue() { }
+        public void methodFeatureDeprecatedResponseAndErrorResponseEqualValue() {
+        }
 
         @FeaturesAreActive(features = "METHOD_FEATURE", responseStatus = 402, errorResponseStatus = HttpStatus.FORBIDDEN)
-        public void methodFeatureDeprecatedResponseAndErrorResponseDifferentValues() { }
+        public void methodFeatureDeprecatedResponseAndErrorResponseDifferentValues() {
+        }
     }
 
     private static class NonAnnotatedTestController {
+
         @SuppressWarnings("unused")
-        public void doit() { }
+        public void doit() {
+        }
     }
 
     @Test
     public void preHandle_noAnnotations() throws Exception {
-        FeatureInterceptor featureInterceptor = new FeatureInterceptor();
-        
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        NonAnnotatedTestController controller = new NonAnnotatedTestController();
-        HandlerMethod handler = new HandlerMethod(controller, "doit");
-        
-        assertEquals(true, featureInterceptor.preHandle(request, response, handler));
+        final FeatureInterceptor featureInterceptor = new FeatureInterceptor();
+
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final NonAnnotatedTestController controller = new NonAnnotatedTestController();
+        final HandlerMethod handler = new HandlerMethod(controller, "doit");
+
+        assertTrue(featureInterceptor.preHandle(request, response, handler));
         assertEquals(200, response.getStatus());
     }
 
     @Test
     public void preHandle_ClassFeature_Inactive() throws Exception {
-        assertPrehandle("classFeature", false, DEFAULT_ERROR_RESPONSE_STATUS);
+        assertPreHandle("classFeature", false, DEFAULT_ERROR_RESPONSE_STATUS);
     }
 
     @Test
     public void preHandle_ClassFeature_Active() throws Exception {
         enableFeature(TestFeatures.CLASS_FEATURE);
-        assertPrehandle("classFeature", true, HttpStatus.OK);
+        assertPreHandle("classFeature", true, HttpStatus.OK);
     }
 
     @Test
     public void preHandle_MethodFeature_Inactive() throws Exception {
-        assertPrehandle("methodFeature", false, DEFAULT_ERROR_RESPONSE_STATUS);
+        assertPreHandle("methodFeature", false, DEFAULT_ERROR_RESPONSE_STATUS);
     }
-    
+
     @Test
     public void preHandle_MethodFeature_Active() throws Exception {
         enableFeature(TestFeatures.METHOD_FEATURE);
-        assertPrehandle("methodFeature", true, HttpStatus.OK);
+        assertPreHandle("methodFeature", true, HttpStatus.OK);
     }
 
     @Test
     public void preHandle_MethodFeatureTwo_Inactive() throws Exception {
-        assertPrehandle("methodFeatureTwo", false, HttpStatus.FOUND);
+        assertPreHandle("methodFeatureTwo", false, HttpStatus.FOUND);
     }
-    
+
     @Test
     public void preHandle_MethodFeatureTwo_OnlyOneActive() throws Exception {
         enableFeature(TestFeatures.METHOD_FEATURE);
-        assertPrehandle("methodFeatureTwo", false, HttpStatus.FOUND);
+        assertPreHandle("methodFeatureTwo", false, HttpStatus.FOUND);
     }
 
     @Test
     public void preHandle_MethodFeatureTwo_AllActive() throws Exception {
         enableFeature(TestFeatures.METHOD_FEATURE);
         enableFeature(TestFeatures.METHOD_FEATURE_TWO);
-        assertPrehandle("methodFeatureTwo", true, HttpStatus.OK);
+        assertPreHandle("methodFeatureTwo", true, HttpStatus.OK);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void preHandle_MethodFeatureAtLeastOneIsNoFeature_AllActualFeaturesActive() throws Exception {
         enableFeature(TestFeatures.METHOD_FEATURE);
         enableFeature(TestFeatures.METHOD_FEATURE_TWO);
-        assertPrehandle("methodFeatureAtLeastOneIsNoFeature", false, DEFAULT_ERROR_RESPONSE_STATUS);
+        assertPreHandle("methodFeatureAtLeastOneIsNoFeature", false, DEFAULT_ERROR_RESPONSE_STATUS);
     }
 
     @Test
     public void preHandle_MethodFeature_preferDeprecatedResponseIfNotDefault() throws Exception {
-        assertPrehandle("methodFeatureDeprecatedResponseStatusNotDefault", false, HttpStatus.valueOf(402));
+        assertPreHandle("methodFeatureDeprecatedResponseStatusNotDefault", false, HttpStatus.valueOf(402));
     }
 
     @Test
     public void preHandle_MethodFeature_preferErrorResponseStatusIfNotDefault() throws Exception {
-        assertPrehandle("methodFeatureErrorResponseStatusNotDefault", false, HttpStatus.FORBIDDEN);
+        assertPreHandle("methodFeatureErrorResponseStatusNotDefault", false, HttpStatus.FORBIDDEN);
     }
 
     @Test
     public void preHandle_MethodFeature_useAnyIfDeprecatedResponseStatusAndErrorResponseStatusAreEqual() throws Exception {
-        assertPrehandle("methodFeatureDeprecatedResponseAndErrorResponseEqualValue", false, HttpStatus.FORBIDDEN);
+        assertPreHandle("methodFeatureDeprecatedResponseAndErrorResponseEqualValue", false, HttpStatus.FORBIDDEN);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void preHandle_MethodFeature_throwISEIfDeprecatedResponseStatusAndErrorResponseStatusAreDifferent() throws Exception {
         // just to compile. the actual value is irrelevant, as there should be an exception because of ambiguous configuration
         final HttpStatus any = HttpStatus.valueOf(200);
-        assertPrehandle("methodFeatureDeprecatedResponseAndErrorResponseDifferentValues", false, any);
+        assertPreHandle("methodFeatureDeprecatedResponseAndErrorResponseDifferentValues", false, any);
     }
 
     @Test
     public void handlerAnnotation_OnType() throws NoSuchMethodException {
-        TestController controller = new TestController();
-        HandlerMethod handler = new HandlerMethod(controller, "classFeature");
-        FeaturesAreActive annotation = FeatureInterceptor.handlerAnnotation(handler, FeaturesAreActive.class);
+        final TestController controller = new TestController();
+        final HandlerMethod handler = new HandlerMethod(controller, "classFeature");
+        final FeaturesAreActive annotation = FeatureInterceptor.handlerAnnotation(handler, FeaturesAreActive.class);
         assertNotNull(annotation);
         assertEquals(DEFAULT_ERROR_RESPONSE_STATUS, annotation.errorResponseStatus());
         assertThat(annotation.features()).containsExactly("CLASS_FEATURE");
@@ -186,27 +191,27 @@ public class FeatureInterceptorTest {
 
     @Test
     public void handlerAnnotation_OnMethod() throws NoSuchMethodException {
-        TestController controller = new TestController();
-        HandlerMethod handler = new HandlerMethod(controller, "methodFeatureTwo");
-        FeaturesAreActive annotation = FeatureInterceptor.handlerAnnotation(handler, FeaturesAreActive.class);
+        final TestController controller = new TestController();
+        final HandlerMethod handler = new HandlerMethod(controller, "methodFeatureTwo");
+        final FeaturesAreActive annotation = FeatureInterceptor.handlerAnnotation(handler, FeaturesAreActive.class);
         assertNotNull(annotation);
         assertEquals(HttpStatus.FOUND, annotation.errorResponseStatus());
         assertThat(annotation.features()).containsExactly("METHOD_FEATURE", "METHOD_FEATURE_TWO");
     }
 
-    private void enableFeature(TestFeatures feature) {
-        repository.setFeatureState(new FeatureState(feature, true));
-        assertTrue(manager.isActive(feature));
+    private void enableFeature(final TestFeatures feature) {
+        this.repository.setFeatureState(new FeatureState(feature, true));
+        assertTrue(this.manager.isActive(feature));
     }
 
-    private void assertPrehandle(String methodName, boolean expectedReturnValue, HttpStatus expectedStatus) throws NoSuchMethodException, Exception {
-        FeatureInterceptor featureInterceptor = new FeatureInterceptor();
-        
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        TestController controller = new TestController();
-        HandlerMethod handler = new HandlerMethod(controller, methodName);
-        
+    private void assertPreHandle(final String methodName, final boolean expectedReturnValue, final HttpStatus expectedStatus) throws NoSuchMethodException, Exception {
+        final FeatureInterceptor featureInterceptor = new FeatureInterceptor();
+
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final TestController controller = new TestController();
+        final HandlerMethod handler = new HandlerMethod(controller, methodName);
+
         assertEquals(expectedReturnValue, featureInterceptor.preHandle(request, response, handler));
         assertEquals(expectedStatus.value(), response.getStatus());
     }


### PR DESCRIPTION
closes #492 

In order to not break current code FeaturesAreActive#responseStatus (1) is set as 'Deprecated'.
FeaturesAreActive#errorResponseStatus (2) which returns org.springframework.http.HttpStatus was introduced.
In order to support the deprecation following behaviour was implemented:
- If (1) and (2) are equal -> fine, return it
- If (1) and (2) are not equal but one is not the default value -> fine, return the non default value
- If (1) and (2) are different and both differ from default value throw IllegalArgumentException