### PR TITLE
Use FeatureGroup without creating annotations on client side

### DIFF
--- a/core/src/main/java/org/togglz/core/annotation/FeatureGroup.java
+++ b/core/src/main/java/org/togglz/core/annotation/FeatureGroup.java
@@ -9,11 +9,17 @@ import java.lang.annotation.Target;
  * 
  * Identifies an annotation type as an feature group annotation
  * 
- * @author Christian Kaltepoth
+ * @author Bennet Schulz
  * 
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
+@Target({ ElementType.FIELD, ElementType.TYPE })
 public @interface FeatureGroup {
 
+    /**
+     * The human readable feature group of this feature
+     *
+     * @return The feature group
+     */
+    String value() default "";
 }

--- a/core/src/main/java/org/togglz/core/metadata/enums/AnnotationFeatureGroup.java
+++ b/core/src/main/java/org/togglz/core/metadata/enums/AnnotationFeatureGroup.java
@@ -8,11 +8,9 @@ import org.togglz.core.metadata.FeatureGroup;
 import org.togglz.core.util.FeatureAnnotations;
 
 /**
- * 
  * An implementation of {@link FeatureGroup} that based on annotations.
- * 
+ *
  * @author Christian Kaltepoth
- * 
  */
 public class AnnotationFeatureGroup implements FeatureGroup {
 
@@ -29,9 +27,27 @@ public class AnnotationFeatureGroup implements FeatureGroup {
         }
     }
 
+    private AnnotationFeatureGroup(Annotation annotation, String value) {
+        this.annotation = annotation.annotationType();
+        Label labelAnnotation = this.annotation.getAnnotation(Label.class);
+        if (labelAnnotation != null) {
+            label = labelAnnotation.value();
+        } else {
+            label = value;
+        }
+    }
+
     public static FeatureGroup build(Class<? extends Annotation> groupAnnotation) {
         if (groupAnnotation.isAnnotationPresent(org.togglz.core.annotation.FeatureGroup.class)) {
             return new AnnotationFeatureGroup(groupAnnotation);
+        }
+        return null;
+    }
+
+    static FeatureGroup build(Annotation annotation, String annotationValue) {
+        String annotationName = annotation.annotationType().getName();
+        if (annotationName.equals(org.togglz.core.annotation.FeatureGroup.class.getCanonicalName())) {
+            return new AnnotationFeatureGroup(annotation, annotationValue);
         }
         return null;
     }

--- a/core/src/main/java/org/togglz/core/metadata/enums/EnumFeatureMetaData.java
+++ b/core/src/main/java/org/togglz/core/metadata/enums/EnumFeatureMetaData.java
@@ -18,12 +18,10 @@ import org.togglz.core.repository.FeatureState;
 import org.togglz.core.util.FeatureAnnotations;
 
 /**
- *
  * Implementation of {@link FeatureMetaData} that looks for annotations like {@link Label}, {@link EnabledByDefault} and
  * {@link DefaultActivationStrategy} on feature enums.
  *
  * @author Christian Kaltepoth
- *
  */
 public class EnumFeatureMetaData implements FeatureMetaData {
 
@@ -46,8 +44,8 @@ public class EnumFeatureMetaData implements FeatureMetaData {
 
         // lookup default activation strategy @DefaultActivationStrategy
         DefaultActivationStrategy defaultActivationStrategy = FeatureAnnotations
-            .getAnnotation(feature, DefaultActivationStrategy.class);
-        if (defaultActivationStrategy != null){
+                .getAnnotation(feature, DefaultActivationStrategy.class);
+        if (defaultActivationStrategy != null) {
             this.defaultFeatureState.setStrategyId(defaultActivationStrategy.id());
 
             for (ActivationParameter parameter : defaultActivationStrategy.parameters()) {
@@ -58,10 +56,20 @@ public class EnumFeatureMetaData implements FeatureMetaData {
         // process annotations on the feature
         for (Annotation annotation : FeatureAnnotations.getAnnotations(feature)) {
 
-            // lookup groups
-            FeatureGroup group = AnnotationFeatureGroup.build(annotation.annotationType());
-            if (group != null) {
-                groups.add(group);
+            FeatureGroup group1 = null;
+            if (annotation instanceof org.togglz.core.annotation.FeatureGroup) {
+                String annotationValue = ((org.togglz.core.annotation.FeatureGroup) annotation).value();
+                group1 = AnnotationFeatureGroup.build(annotation, annotationValue);
+                if (group1 != null) {
+                    groups.add(group1);
+                }
+            }
+            if(group1 == null) {
+                // lookup groups
+                FeatureGroup group = AnnotationFeatureGroup.build(annotation.annotationType());
+                if (group != null) {
+                    groups.add(group);
+                }
             }
 
             // check if this annotation is a feature attribute
@@ -69,9 +77,7 @@ public class EnumFeatureMetaData implements FeatureMetaData {
             if (attribute != null) {
                 attributes.put(attribute[0], attribute[1]);
             }
-
         }
-
     }
 
     @Override

--- a/core/src/test/java/org/togglz/core/metadata/enums/AnnotationFeatureGroupTest.java
+++ b/core/src/test/java/org/togglz/core/metadata/enums/AnnotationFeatureGroupTest.java
@@ -39,14 +39,14 @@ class AnnotationFeatureGroupTest {
     }
 
     @Test
-    void buildWillReturnNullWhenFeatureGroupAnnotationIsNotPresent() throws Exception {
+    void buildWillReturnNullWhenFeatureGroupAnnotationIsNotPresent() {
         FeatureGroup result = AnnotationFeatureGroup.build(Label.class);
 
         assertNull(result);
     }
 
     @Test
-    void buildWillReturnFeatureGroupWhenFeatureGroupAnnotationIsPresentForFieldLevelGroup() throws Exception {
+    void buildWillReturnFeatureGroupWhenFeatureGroupAnnotationIsPresentForFieldLevelGroup() {
         FeatureGroup result = AnnotationFeatureGroup.build(FieldLevelGroup.class);
 
         assertNotNull(result);
@@ -55,7 +55,7 @@ class AnnotationFeatureGroupTest {
     }
 
     @Test
-    void buildWillReturnFeatureGroupWhenFeatureGroupAnnotationIsPresentForClassLevelGroup() throws Exception {
+    void buildWillReturnFeatureGroupWhenFeatureGroupAnnotationIsPresentForClassLevelGroup() {
         FeatureGroup result = AnnotationFeatureGroup.build(ClassLevelGroup.class);
 
         assertNotNull(result);

--- a/core/src/test/java/org/togglz/core/metadata/enums/EnumFeatureMetaDataTest.java
+++ b/core/src/test/java/org/togglz/core/metadata/enums/EnumFeatureMetaDataTest.java
@@ -45,19 +45,25 @@ public class EnumFeatureMetaDataTest {
         @FieldLevelGroup
         FEATURE,
 
+        @org.togglz.core.annotation.FeatureGroup("hello")
+        FEATURE_WITHOUT_MANUALLY_CREATED_ANNOTATION,
+
+        @org.togglz.core.annotation.FeatureGroup
+        FEATURE_WITHOUT_MANUALLY_CREATED_ANNOTATION2,
+
         @EnabledByDefault
         @DefaultActivationStrategy(
-            id = "SomeActivationId",
-            parameters = {
-                @ActivationParameter(name = "SomeParameterName", value = "someValue1,someValue2"),
-                @ActivationParameter(name = "SomeParameterName2", value = "someValue3,someValue4")
-            }
+                id = "SomeActivationId",
+                parameters = {
+                        @ActivationParameter(name = "SomeParameterName", value = "someValue1,someValue2"),
+                        @ActivationParameter(name = "SomeParameterName2", value = "someValue3,someValue4")
+                }
         )
         FEATURE_WITH_DEFAULT_STATE;
     }
 
     @Test
-    public void constructorWillPopulateGroupsFromAnnotations() throws Exception {
+    void constructorWillPopulateGroupsFromAnnotations() {
         // act
         EnumFeatureMetaData metaData = new EnumFeatureMetaData(TestFeatures.FEATURE);
 
@@ -77,7 +83,7 @@ public class EnumFeatureMetaDataTest {
     }
 
     @Test
-    public void constructorWillPopulateDefaultActivationStrategyFromAnnotations() throws Exception {
+    void constructorWillPopulateDefaultActivationStrategyFromAnnotations() {
         // act
         EnumFeatureMetaData metaData = new EnumFeatureMetaData(TestFeatures.FEATURE_WITH_DEFAULT_STATE);
 
@@ -88,6 +94,32 @@ public class EnumFeatureMetaDataTest {
         assertEquals("SomeActivationId", featureState.getStrategyId());
         assertEquals("someValue1,someValue2", featureState.getParameter("SomeParameterName"));
         assertEquals("someValue3,someValue4", featureState.getParameter("SomeParameterName2"));
+    }
+
+    @Test
+    void shouldCreateFeatureGroupWhenGroupNameIsAddedAsAnnotationValue() {
+        EnumFeatureMetaData metaData = new EnumFeatureMetaData(TestFeatures.FEATURE_WITHOUT_MANUALLY_CREATED_ANNOTATION);
+
+        Set<FeatureGroup> groups = metaData.getGroups();
+
+        assertNotNull(groups);
+        assertEquals(2, groups.size());
+
+        List<FeatureGroup> group = groups.stream().filter(createFeatureGroupLabelPredicate("hello")).collect(Collectors.toList());
+        assertTrue(group.get(0).contains(TestFeatures.FEATURE_WITHOUT_MANUALLY_CREATED_ANNOTATION));
+    }
+
+    @Test
+    void shouldCreateFeatureGroupWhenGroupNameIsAddedAsAnnotationValue2() {
+        EnumFeatureMetaData metaData = new EnumFeatureMetaData(TestFeatures.FEATURE_WITHOUT_MANUALLY_CREATED_ANNOTATION2);
+
+        Set<FeatureGroup> groups = metaData.getGroups();
+
+        assertNotNull(groups);
+        assertEquals(2, groups.size());
+
+        List<FeatureGroup> group = groups.stream().filter(createFeatureGroupLabelPredicate("")).collect(Collectors.toList());
+        assertTrue(group.get(0).contains(TestFeatures.FEATURE_WITHOUT_MANUALLY_CREATED_ANNOTATION2));
     }
 
     private Predicate<FeatureGroup> createFeatureGroupLabelPredicate(final String label) {


### PR DESCRIPTION
In  the previous releases of togglz the user would have to create annotations on client side to use FeatureGroups

```
@FeatureGroup
@Label("Oldschool Feature Group")
@Target(ElementType.FIELD)
@Retention(RetentionPolicy.RUNTIME)
public @interface OldSchoolFeatureGroup {
}
```
---
```
@Label("feature group as we know it since ever")
@EnabledByDefault
@OldSchoolFeatureGroup
FEATURE_B,

@Label("new type of declaring feature groups")
@FeatureGroup("group for C features")
FEATURE_C,
```

Since the upcoming release it's possible to group feature toggles either with the old school way (creating an annotation like @OldSchoolFeatureGroup) and use it in the respective feature enum.
Now it's possible to create groups like in FEATURE_C by adding it as a String value to the @FeatureGroup annotation