### PR TITLE
add property to activate CSRF token validation

### DIFF
--- a/console/src/main/java/org/togglz/console/RequestContext.java
+++ b/console/src/main/java/org/togglz/console/RequestContext.java
@@ -1,0 +1,34 @@
+package org.togglz.console;
+
+public class RequestContext {
+
+    private final boolean validateCSRFToken;
+
+    private RequestContext(Builder builder) {
+        validateCSRFToken = builder.validateCSRFToken;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public boolean isValidateCSRFToken() {
+        return validateCSRFToken;
+    }
+
+    public static final class Builder {
+        private boolean validateCSRFToken;
+
+        private Builder() {
+        }
+
+        public Builder withValidateCSRFToken(boolean val) {
+            validateCSRFToken = val;
+            return this;
+        }
+
+        public RequestContext build() {
+            return new RequestContext(this);
+        }
+    }
+}

--- a/console/src/main/java/org/togglz/console/RequestEvent.java
+++ b/console/src/main/java/org/togglz/console/RequestEvent.java
@@ -13,13 +13,15 @@ public class RequestEvent {
     private final HttpServletResponse response;
     private final String path;
     private final FeatureManager featureManager;
+    private final RequestContext requestContext;
 
     public RequestEvent(FeatureManager featureManager, ServletContext context, HttpServletRequest request,
-        HttpServletResponse response) {
+                        HttpServletResponse response, RequestContext requestContext) {
         this.featureManager = featureManager;
         this.context = context;
         this.request = request;
         this.response = response;
+        this.requestContext = requestContext;
 
         // /contextPath/togglz/index -> /index
         String prefix = request.getContextPath() + request.getServletPath();
@@ -27,6 +29,10 @@ public class RequestEvent {
             .substring(prefix.length())
             .replaceAll("(?i);jsessionid=[\\w\\.\\-]+", "");
 
+    }
+
+    public RequestContext getRequestContext() {
+        return requestContext;
     }
 
     public ServletContext getContext() {

--- a/console/src/main/java/org/togglz/console/TogglzConsoleServlet.java
+++ b/console/src/main/java/org/togglz/console/TogglzConsoleServlet.java
@@ -25,6 +25,7 @@ public class TogglzConsoleServlet extends HttpServlet {
     protected FeatureManager featureManager;
 
     protected boolean secured = true;
+    protected boolean validateCSRFToken = true;
 
     @Override
     public void init(ServletConfig config) {
@@ -36,6 +37,11 @@ public class TogglzConsoleServlet extends HttpServlet {
             this.secured = toBool(secured);
         }
 
+        String validateCSRFToken = servletContext.getInitParameter("org.togglz.console.validateCSRFToken");
+        if (validateCSRFToken != null) {
+            this.validateCSRFToken = toBool(validateCSRFToken);
+        }
+
         // build list of request handlers
         for (RequestHandler requestHandler : ServiceLoader.load(RequestHandler.class)) {
             handlers.add(requestHandler);
@@ -45,7 +51,10 @@ public class TogglzConsoleServlet extends HttpServlet {
     @Override
     protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException {
         RequestEvent consoleRequest =
-            new RequestEvent(featureManager, servletContext, request, response);
+                new RequestEvent(featureManager, servletContext, request, response,
+                        RequestContext.newBuilder()
+                                .withValidateCSRFToken(validateCSRFToken)
+                                .build());
         String path = consoleRequest.getPath();
 
         RequestHandler handler = getHandlerFor(path);
@@ -81,6 +90,10 @@ public class TogglzConsoleServlet extends HttpServlet {
 
     public void setSecured(boolean secured) {
         this.secured = secured;
+    }
+
+    public void setValidateCSRFToken(boolean validateCSRFToken) {
+        this.validateCSRFToken = validateCSRFToken;
     }
 
     private static boolean toBool(String value) {

--- a/console/src/main/java/org/togglz/console/handlers/edit/EditPageHandler.java
+++ b/console/src/main/java/org/togglz/console/handlers/edit/EditPageHandler.java
@@ -92,15 +92,18 @@ public class EditPageHandler extends RequestHandlerBase {
     }
 
     private boolean validateCSRFToken(RequestEvent event) {
-    	boolean isValid = true;
-		for (CSRFTokenValidator validator : Services.get(CSRFTokenValidator.class)) {
-			if(!validator.isTokenValid(event.getRequest())){
-				isValid = false;
-				break;
-			}
-		}
-		return isValid;
-	}
+        boolean isValid = true;
+        if (event.getRequestContext().isValidateCSRFToken()) {
+            for (CSRFTokenValidator validator : Services.get(CSRFTokenValidator.class)) {
+                if (!validator.isTokenValid(event.getRequest())) {
+                    isValid = false;
+                    break;
+                }
+            }
+        }
+
+        return isValid;
+    }
 
     private void renderErrorPage(RequestEvent event) throws IOException {
 		String template = getResourceAsString("error.html");

--- a/spring-boot/starter/src/main/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzConsoleBaseConfiguration.java
+++ b/spring-boot/starter/src/main/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzConsoleBaseConfiguration.java
@@ -46,6 +46,7 @@ public abstract class TogglzConsoleBaseConfiguration {
         String urlMapping = (path.endsWith("/") ? path + "*" : path + "/*");
         TogglzConsoleServlet servlet = new TogglzConsoleServlet();
         servlet.setSecured(properties.getConsole().isSecured());
+        servlet.setValidateCSRFToken(properties.getConsole().isValidateCSRFToken());
         return new ServletRegistrationBean(servlet, urlMapping);
     }
 

--- a/spring-boot/starter/src/main/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzProperties.java
+++ b/spring-boot/starter/src/main/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzProperties.java
@@ -322,9 +322,18 @@ public class TogglzProperties {
 		private boolean secured = true;
 
 		/**
+		 * Validates the csrf token during toggle update for a single instance.
+		 */
+		private boolean validateCSRFToken = true;
+
+		/**
 		 * Indicates if the admin console runs on the management port.
 		 */
 		private boolean useManagementPort = true;
+
+		public boolean isValidateCSRFToken() {
+			return validateCSRFToken;
+		}
 
 		public boolean isEnabled() {
 			return enabled;


### PR DESCRIPTION
This commit should enable the system to deactivate CSRFToken-Validation using the property:   `org.togglz.console.validateCSRFToken=false`

This way having multiple instances would not result in flaky responses in the console during toggle updates.

Nevertheless token validation is still activated by default