### PR TITLE
Upgrade hazelcast major version

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -13,7 +13,7 @@
 	<description>Togglz - Hazelcast integration</description>
 
 	<properties>
-		<hazelcast.version>3.12.9</hazelcast.version>
+		<hazelcast.version>4.2</hazelcast.version>
 	</properties>
 
 	<dependencies>
@@ -25,11 +25,6 @@
 		<dependency>
 			<groupId>com.hazelcast</groupId>
 			<artifactId>hazelcast</artifactId>
-			<version>${hazelcast.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.hazelcast</groupId>
-			<artifactId>hazelcast-client</artifactId>
 			<version>${hazelcast.version}</version>
 		</dependency>
 

--- a/hazelcast/src/main/java/org/togglz/hazelcast/HazelcastStateRepository.java
+++ b/hazelcast/src/main/java/org/togglz/hazelcast/HazelcastStateRepository.java
@@ -5,7 +5,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 import org.togglz.core.Feature;
 import org.togglz.core.repository.FeatureState;
 import org.togglz.core.repository.StateRepository;

--- a/hazelcast/src/test/java/org/togglz/hazelcast/HazelcastStateRepositoryTest.java
+++ b/hazelcast/src/test/java/org/togglz/hazelcast/HazelcastStateRepositoryTest.java
@@ -14,10 +14,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class HazelcastStateRepositoryTest {
 
-	private final StateRepository stateRepository = HazelcastStateRepository.newBuilder().mapName("togglzMap").build();
-
 	@Test
 	void testSetFeatureStateNotExistingInMap() {
+		final StateRepository stateRepository = HazelcastStateRepository.newBuilder().mapName("togglzMap").build();
 		final Feature feature = new NamedFeature("SAMPLE_FEATURE");
 		final FeatureState featureState = new FeatureState(feature, true);
 		stateRepository.setFeatureState(featureState);
@@ -29,6 +28,7 @@ class HazelcastStateRepositoryTest {
 
 	@Test
 	void testSetFeatureStateExistingInMap() {
+		final StateRepository stateRepository = HazelcastStateRepository.newBuilder().mapName("togglzMap").build();
 		final Feature feature = new NamedFeature("SAMPLE_FEATURE");
 		final FeatureState featureState = new FeatureState(feature, true);
 		stateRepository.setFeatureState(featureState);
@@ -43,6 +43,24 @@ class HazelcastStateRepositoryTest {
 		assertFalse(storedFeatureState.isEnabled());
 
 		assertTrue(EqualsBuilder.reflectionEquals(featureState, storedFeatureState, true));
+	}
+
+	@Test
+	void test2nodeSetup(){
+		final StateRepository stateRepository1 = HazelcastStateRepository.newBuilder().mapName("togglzMap").build();
+		final StateRepository stateRepository2 = HazelcastStateRepository.newBuilder().mapName("togglzMap").build();
+		final Feature feature = new NamedFeature("SAMPLE_FEATURE");
+		final FeatureState featureState = new FeatureState(feature, false);
+		stateRepository1.setFeatureState(featureState);
+
+		assertFalse(stateRepository1.getFeatureState(feature).isEnabled());
+		assertFalse(stateRepository2.getFeatureState(feature).isEnabled());
+
+		featureState.setEnabled(true);
+		stateRepository1.setFeatureState(featureState);
+
+		assertTrue(stateRepository1.getFeatureState(feature).isEnabled());
+		assertTrue(stateRepository2.getFeatureState(feature).isEnabled());
 	}
 
 	@Test


### PR DESCRIPTION
# Upgrade hazelcast major version
_Now at 4.2_

https://hazelcast.com/blog/hazelcast-imdg-4-0-is-released/
> A key thing to note is that the client protocol has also been updated in 4.0. This means that you cannot use a 3.x client with 4.0 members. This is something that only changes on a major release. Once you upgrade your clients to 4.x then you can continue to use them with various 4.x Member versions.

The client lib is now included in the core lib, and no longer needed.
The package of IMap has moved from core to map, not much else is new, apart from compatibility.