### PR TITLE
ByteBuddy-generated proxies

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>togglz-zookeeper</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <version>3.1.0</version>

--- a/benchmarks/src/main/java/org/togglz/benchmark/ByteBuddyProxyBenchmark.java
+++ b/benchmarks/src/main/java/org/togglz/benchmark/ByteBuddyProxyBenchmark.java
@@ -40,6 +40,7 @@ public class ByteBuddyProxyBenchmark {
   private static final Supplier<String> sayHello = () -> "Hello";
   private static final Supplier<String> sayWorld = () -> "World";
 
+  Supplier<String> passiveProxy;
   Supplier<String> proxy;
   Supplier<String> handCoded;
   Supplier<String> handCoded2;
@@ -95,6 +96,9 @@ public class ByteBuddyProxyBenchmark {
     // Create switching proxies for different tests
     proxy = ByteBuddyProxyFactory.proxyFor(
       ProxyFeature.ENABLED, Supplier.class, sayHello, sayWorld, featureManager);
+    passiveProxy = ByteBuddyProxyFactory.passiveProxyFor(
+      ProxyFeature.ENABLED, Supplier.class, sayHello, sayWorld, featureManager);
+
     handCoded = new HandCodedSwitchable(
       featureManager, ProxyFeature.ENABLED, sayHello, sayWorld);
     handCoded2 = new HandCodedSwitchable2(featureManager, ProxyFeature.ENABLED, sayHello, sayWorld);
@@ -104,8 +108,14 @@ public class ByteBuddyProxyBenchmark {
 
   @Benchmark
   // Full auto-generated proxy
-  public String generatedProxy() {
+  public String activeProxy() {
     return proxy.get();
+  }
+
+  @Benchmark
+  // Full auto-generated passive proxy
+  public String passiveProxy() {
+    return passiveProxy.get();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/org/togglz/benchmark/ByteBuddyProxyBenchmark.java
+++ b/benchmarks/src/main/java/org/togglz/benchmark/ByteBuddyProxyBenchmark.java
@@ -1,0 +1,139 @@
+package org.togglz.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.togglz.core.Feature;
+import org.togglz.core.context.StaticFeatureManagerProvider;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.manager.FeatureManagerBuilder;
+import org.togglz.core.proxy.ByteBuddyProxyFactory;
+import org.togglz.core.proxy.TogglzSwitchable;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.repository.mem.InMemoryStateRepository;
+import org.togglz.core.user.NoOpUserProvider;
+
+/**
+ * Compare the overhead of togglz JDK Proxy with an in-memory state repository vs a direct call
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Measurement(batchSize = 1000, iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(batchSize = 1000, iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Threads(7)
+public class ByteBuddyProxyBenchmark {
+
+  private static final Supplier<String> sayHello = () -> "Hello";
+  private static final Supplier<String> sayWorld = () -> "World";
+
+  Supplier<String> proxy;
+  Supplier<String> handCoded;
+  Supplier<String> handCoded2;
+
+  FeatureManager featureManager;
+
+  public static final class HandCodedSwitchable extends TogglzSwitchable<Supplier<String>> implements Supplier<String> {
+    public HandCodedSwitchable(FeatureManager featureManager, Feature feature, Supplier<String> active, Supplier<String> inactive) {
+      super(featureManager, feature, active, inactive);
+    }
+
+    public String get() {
+      super.checkTogglzState();
+      return delegate.get();
+    }
+  }
+
+  public static final class HandCodedSwitchable2 implements Supplier<String> {
+    private final FeatureManager featureManager;
+    private final Feature feature;
+    private final Supplier<String> active;
+    private final Supplier<String> inactive;
+
+    public HandCodedSwitchable2(FeatureManager featureManager, Feature feature, Supplier<String> active, Supplier<String> inactive) {
+      this.featureManager = featureManager;
+      this.feature = feature;
+      this.active = active;
+      this.inactive = inactive;
+    }
+
+    public String get() {
+      return featureManager.isActive(feature) ? active.get() : inactive.get();
+    }
+  }
+
+  private enum ProxyFeature implements Feature {
+    ENABLED
+  }
+
+  @SuppressWarnings("unchecked")
+  @Setup(Level.Trial)
+  public void setupFeatureManager() {
+
+    // create an in-memory state repository for our feature
+    featureManager = new FeatureManagerBuilder()
+      .featureEnums(ProxyFeature.class)
+      .stateRepository(new InMemoryStateRepository())
+      .userProvider(new NoOpUserProvider())
+      .build();
+    // set the StaticFeatureManagerProvider to use this feature manager
+    StaticFeatureManagerProvider.setFeatureManager(featureManager);
+
+    // Create switching proxies for different tests
+    proxy = ByteBuddyProxyFactory.proxyFor(
+      ProxyFeature.ENABLED, Supplier.class, sayHello, sayWorld, featureManager);
+    handCoded = new HandCodedSwitchable(
+      featureManager, ProxyFeature.ENABLED, sayHello, sayWorld);
+    handCoded2 = new HandCodedSwitchable2(featureManager, ProxyFeature.ENABLED, sayHello, sayWorld);
+
+    featureManager.setFeatureState(new FeatureState(ProxyFeature.ENABLED, true));
+  }
+
+  @Benchmark
+  // Full auto-generated proxy
+  public String generatedProxy() {
+    return proxy.get();
+  }
+
+  @Benchmark
+  // Same design as the auto-generated code to highlight any inefficiency in ByteBuddy solution.
+  public String handCodedTogglzSwitchable() {
+    return handCoded.get();
+  }
+
+  @Benchmark
+  // A common style of hand-coded solution
+  public String handCodedSwitch() {
+    return handCoded2.get();
+  }
+
+  @Benchmark
+  // Baseline performance of calling the targeted object directly
+  public String directCall() {
+    return sayHello.get();
+  }
+
+  // run this method to execute this test
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+      .include(ByteBuddyProxyBenchmark.class.getSimpleName())
+      .forks(1)
+      .build();
+
+    new Runner(opt).run();
+  }
+
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,6 +14,12 @@
 
   <dependencies>
     <dependency>
+      <!-- Used by proxy generation -->
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>3.19.0</version>

--- a/core/src/main/java/org/togglz/core/proxy/ByteBuddyProxyFactory.java
+++ b/core/src/main/java/org/togglz/core/proxy/ByteBuddyProxyFactory.java
@@ -1,6 +1,8 @@
 package org.togglz.core.proxy;
 
 import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.NamingStrategy;
+import net.bytebuddy.NamingStrategy.SuffixingRandom.BaseNameResolver.ForGivenType;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.implementation.MethodCall;
 import net.bytebuddy.implementation.MethodDelegation;
@@ -9,6 +11,7 @@ import org.togglz.core.logging.Log;
 import org.togglz.core.logging.LogFactory;
 import org.togglz.core.manager.FeatureManager;
 import org.togglz.core.manager.LazyResolvingFeatureManager;
+import static net.bytebuddy.description.type.TypeDescription.ForLoadedType.of;
 import static net.bytebuddy.description.type.TypeDescription.Generic.Builder.parameterizedType;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 import static net.bytebuddy.matcher.ElementMatchers.isDefaultMethod;
@@ -55,7 +58,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
  */
 public class ByteBuddyProxyFactory {
 
-  // TODO Nice naming for classes
+  // TODO delegate toString()
   // TODO where is the type-caching?
 
   private static final Log log = LogFactory.getLog(ByteBuddyProxyFactory.class);
@@ -110,6 +113,7 @@ public class ByteBuddyProxyFactory {
     Implementation.Composable passiveProxyImpl = MethodDelegation.toField("delegate");
 
     Class<?> clazz = new ByteBuddy()
+      .with(new NamingStrategy.SuffixingRandom("togglz", new ForGivenType(of(interfaceClass))))
       .subclass(parameterizedType(TogglzSwitchable.class, interfaceClass).build())
       .implement(interfaceClass)
 

--- a/core/src/main/java/org/togglz/core/proxy/ByteBuddyProxyFactory.java
+++ b/core/src/main/java/org/togglz/core/proxy/ByteBuddyProxyFactory.java
@@ -1,6 +1,7 @@
 package org.togglz.core.proxy;
 
 import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.implementation.MethodCall;
 import net.bytebuddy.implementation.MethodDelegation;
 import org.togglz.core.Feature;
@@ -9,17 +10,19 @@ import org.togglz.core.logging.LogFactory;
 import org.togglz.core.manager.FeatureManager;
 import org.togglz.core.manager.LazyResolvingFeatureManager;
 import static net.bytebuddy.description.type.TypeDescription.Generic.Builder.parameterizedType;
-import static net.bytebuddy.matcher.ElementMatchers.*;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
+import static net.bytebuddy.matcher.ElementMatchers.isDefaultMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 /**
  * Produces switching proxy implementations which delegate invocation to one of two objects depending on the state of the specified {@link Feature}.
- * <p>Assuming a provided interface ...
+ *
+ * <h2>Generated Code</h2>
+ * Assuming a user interface ...
  * <pre>
- * public interface UserDAO { User findById(int id); }
- * </pre>
- * ... this will generate classes equivalent to the following source code ...
+ * public interface UserDAO { User findById(int id); }</pre>
+ * ... {@link #proxyFor} will generate classes equivalent to the following source code ...
  * <pre>
  * public class X extends TogglzSwitchable<UserDAO> implements UserDAO {
  *   public X(FeatureManager featureManager, Feature feature, UserDAO active, UserDAO inactive) {
@@ -29,48 +32,97 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
  *     super.checkTogglzState();
  *     return delegate.findById(id);
  *   }
- * }
- * </pre>
- * State is checked as part of <i>every method call</i> which is invisible but also quite invasive.
+ * } </pre>
+ *
+ * <h2>Active and Passive mode</h2>
+ * In "active" proxies, {@link Feature} state is checked as part of <i>every method call</i> which is invisible but also
+ * quite slow. It may also be functionally dangerous if the implementations are stateful and should not flipped in the
+ * middle of a "session".
+ * <p>For these cases {@code passiveProxyFor(...)} will generate classes that never check the feature state themselves.
+ * To be updated they must be passed to {@link TogglzSwitchable#update(Object)}.
+ *
+ * <h2>Performance</h2>
+ * Following gives approximate invocation overhead of using a {@link Feature}-controlled proxy vs direct calls.
+ *
+ * <table border="1">
+ *   <tr><td>Direct Call</td> <td>100%</td></tr>
+ *     <tr><td>Passive ByteBuddy Proxy</td> <td>70%</td></tr>
+ *     <tr><td>Active ByteBuddy Proxy</td> <td>15%</td></tr>
+ *     <tr><td>JDK Proxy</td> <td>10%</td></tr>
+ * </table>
+ *
  * @see TogglzSwitchable
  */
 public class ByteBuddyProxyFactory {
 
   // TODO Nice naming for classes
   // TODO where is the type-caching?
-  // TODO active/passive alternatives
 
   private static final Log log = LogFactory.getLog(ByteBuddyProxyFactory.class);
 
-  public static <T> T proxyFor(Feature feature, Class<? super T> interfaceClass,T active, T inactive) {
-    return proxyFor(feature, interfaceClass, active, inactive, new LazyResolvingFeatureManager());
+  /**
+   * Generate a passive {@link Feature} proxy.
+   *
+   * @see ByteBuddyProxyFactory
+   */
+  public static <T> T passiveProxyFor(Feature feature, Class<? super T> interfaceClass, T active, T inactive) {
+    return generateProxy(feature, interfaceClass, active, inactive, new LazyResolvingFeatureManager(), true);
   }
 
-  public static <T> T proxyFor(Feature feature, Class<? super T> interfaceClass, T active, T inactive, FeatureManager featureManager) {
-    try {
-      Class<?> clazz = generateProxyClass(interfaceClass);
+  /**
+   * Generate a passive {@link Feature} proxy.
+   *
+   * @see ByteBuddyProxyFactory
+   */
+  public static <T> T passiveProxyFor(Feature feature, Class<? super T> interfaceClass, T active, T inactive, FeatureManager featureManager) {
+    return generateProxy(feature, interfaceClass, active, inactive, featureManager, true);
+  }
 
+  /**
+   * Generate an active {@link Feature} proxy.
+   *
+   * @see ByteBuddyProxyFactory
+   */
+  public static <T> T proxyFor(Feature feature, Class<? super T> interfaceClass, T active, T inactive) {
+    return generateProxy(feature, interfaceClass, active, inactive, new LazyResolvingFeatureManager(), false);
+  }
+
+  /**
+   * Generate an active {@link Feature} proxy.
+   *
+   * @see ByteBuddyProxyFactory
+   */
+  public static <T> T proxyFor(Feature feature, Class<? super T> interfaceClass, T active, T inactive, FeatureManager featureManager) {
+    return generateProxy(feature, interfaceClass, active, inactive, featureManager, false);
+  }
+
+  private static <T> T generateProxy(Feature feature, Class<? super T> interfaceClass, T active, T inactive, FeatureManager featureManager, boolean passiveProxy) {
+    try {
+      Class<?> clazz = generateProxyClass(interfaceClass, passiveProxy);
       return (T)clazz.getConstructors()[0].newInstance(featureManager, feature, active, inactive);
     } catch (Exception e) {
-      throw new RuntimeException("Failed to create proxy for "+interfaceClass.getSimpleName(), e);
+      throw new RuntimeException("Failed to create proxy for " + interfaceClass.getSimpleName(), e);
     }
   }
 
-  private static Class<?> generateProxyClass(Class<?> interfaceClass) {
+  private static Class<?> generateProxyClass(Class<?> interfaceClass, boolean passiveProxy) {
+    Implementation.Composable activeProxyImpl = MethodCall.invoke(named("checkTogglzState")).onSuper().andThen(MethodDelegation.toField("delegate"));
+    Implementation.Composable passiveProxyImpl = MethodDelegation.toField("delegate");
+
     Class<?> clazz = new ByteBuddy()
       .subclass(parameterizedType(TogglzSwitchable.class, interfaceClass).build())
       .implement(interfaceClass)
 
       // Define the interface methods excluding any that have default impls.
       .method(isDeclaredBy(interfaceClass).and(not(isDefaultMethod())))
-      .intercept(MethodCall.invoke(named("checkTogglzState")).onSuper().andThen(MethodDelegation.toField("delegate")))
+      .intercept(passiveProxy ? passiveProxyImpl : activeProxyImpl)
 
       .make()
       .load(Thread.currentThread().getContextClassLoader())
       .getLoaded();
 
-    if( log.isDebugEnabled() ) {
-      log.debug("Generated class "+clazz.getName()+" implements "+interfaceClass.getSimpleName());
+    if (log.isDebugEnabled()) {
+      log.debug("Generated class " + clazz.getName() + " implements " + interfaceClass.getSimpleName());
     }
 
     return clazz;

--- a/core/src/main/java/org/togglz/core/proxy/ByteBuddyProxyFactory.java
+++ b/core/src/main/java/org/togglz/core/proxy/ByteBuddyProxyFactory.java
@@ -1,0 +1,79 @@
+package org.togglz.core.proxy;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.implementation.MethodCall;
+import net.bytebuddy.implementation.MethodDelegation;
+import org.togglz.core.Feature;
+import org.togglz.core.logging.Log;
+import org.togglz.core.logging.LogFactory;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.manager.LazyResolvingFeatureManager;
+import static net.bytebuddy.description.type.TypeDescription.Generic.Builder.parameterizedType;
+import static net.bytebuddy.matcher.ElementMatchers.*;
+import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+/**
+ * Produces switching proxy implementations which delegate invocation to one of two objects depending on the state of the specified {@link Feature}.
+ * <p>Assuming a provided interface ...
+ * <pre>
+ * public interface UserDAO { User findById(int id); }
+ * </pre>
+ * ... this will generate classes equivalent to the following source code ...
+ * <pre>
+ * public class X extends TogglzSwitchable<UserDAO> implements UserDAO {
+ *   public X(FeatureManager featureManager, Feature feature, UserDAO active, UserDAO inactive) {
+ *     super(featureManager, feature, active, inactive);
+ *   }
+ *   public User findById(int id) {
+ *     super.checkTogglzState();
+ *     return delegate.findById(id);
+ *   }
+ * }
+ * </pre>
+ * State is checked as part of <i>every method call</i> which is invisible but also quite invasive.
+ * @see TogglzSwitchable
+ */
+public class ByteBuddyProxyFactory {
+
+  // TODO Nice naming for classes
+  // TODO where is the type-caching?
+  // TODO active/passive alternatives
+
+  private static final Log log = LogFactory.getLog(ByteBuddyProxyFactory.class);
+
+  public static <T> T proxyFor(Feature feature, Class<? super T> interfaceClass,T active, T inactive) {
+    return proxyFor(feature, interfaceClass, active, inactive, new LazyResolvingFeatureManager());
+  }
+
+  public static <T> T proxyFor(Feature feature, Class<? super T> interfaceClass, T active, T inactive, FeatureManager featureManager) {
+    try {
+      Class<?> clazz = generateProxyClass(interfaceClass);
+
+      return (T)clazz.getConstructors()[0].newInstance(featureManager, feature, active, inactive);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create proxy for "+interfaceClass.getSimpleName(), e);
+    }
+  }
+
+  private static Class<?> generateProxyClass(Class<?> interfaceClass) {
+    Class<?> clazz = new ByteBuddy()
+      .subclass(parameterizedType(TogglzSwitchable.class, interfaceClass).build())
+      .implement(interfaceClass)
+
+      // Define the interface methods excluding any that have default impls.
+      .method(isDeclaredBy(interfaceClass).and(not(isDefaultMethod())))
+      .intercept(MethodCall.invoke(named("checkTogglzState")).onSuper().andThen(MethodDelegation.toField("delegate")))
+
+      .make()
+      .load(Thread.currentThread().getContextClassLoader())
+      .getLoaded();
+
+    if( log.isDebugEnabled() ) {
+      log.debug("Generated class "+clazz.getName()+" implements "+interfaceClass.getSimpleName());
+    }
+
+    return clazz;
+  }
+
+}

--- a/core/src/main/java/org/togglz/core/proxy/TogglzSwitchable.java
+++ b/core/src/main/java/org/togglz/core/proxy/TogglzSwitchable.java
@@ -1,0 +1,33 @@
+package org.togglz.core.proxy;
+
+import org.togglz.core.Feature;
+import org.togglz.core.manager.FeatureManager;
+
+/**
+ * Simple switch which sets its delegate to one of two objects depending on the state of the specified {@link Feature}.
+ * @see ByteBuddyProxyFactory ByteBuddyProxyFactory uses this as the baseclass for generated proxies
+ */
+public abstract class TogglzSwitchable<T> {
+  private final FeatureManager featureManager;
+  private final Feature feature;
+  private final T active;
+  private final T inactive;
+  protected T delegate;
+
+  public TogglzSwitchable(FeatureManager featureManager, Feature feature, T active, T inactive) {
+    this.featureManager = featureManager;
+    this.feature = feature;
+    this.active = active;
+    this.inactive = inactive;
+
+    delegate = featureManager.isActive(feature) ? active : inactive;
+  }
+
+  protected final void checkTogglzState() {
+    boolean configured = featureManager.isActive(feature);
+    boolean operational = delegate == active;
+    if (configured ^ operational) { // Less field writes -> more JIT optimisations
+      delegate = configured ? active : inactive;
+    }
+  }
+}

--- a/core/src/main/java/org/togglz/core/proxy/TogglzSwitchable.java
+++ b/core/src/main/java/org/togglz/core/proxy/TogglzSwitchable.java
@@ -23,11 +23,25 @@ public abstract class TogglzSwitchable<T> {
     delegate = featureManager.isActive(feature) ? active : inactive;
   }
 
+  /**
+   * Updates the internal delegate selection against the {@link Feature} state.
+   */
   protected final void checkTogglzState() {
     boolean configured = featureManager.isActive(feature);
     boolean operational = delegate == active;
     if (configured ^ operational) { // Less field writes -> more JIT optimisations
       delegate = configured ? active : inactive;
+    }
+  }
+
+  /**
+   * Manually update the internal delegation of a {@link TogglzSwitchable} against its
+   * {@link Feature} state. This is intended for use with passive switching.
+   * @param o The object to update. If null or not a {@link TogglzSwitchable}, no action is taken.
+   */
+  public static void update(Object o) {
+    if ( o instanceof TogglzSwitchable) {
+      ((TogglzSwitchable<?>)o).checkTogglzState();
     }
   }
 }

--- a/core/src/test/java/org/togglz/core/proxy/ByteBuddyProxyFactoryTest.java
+++ b/core/src/test/java/org/togglz/core/proxy/ByteBuddyProxyFactoryTest.java
@@ -38,11 +38,22 @@ class ByteBuddyProxyFactoryTest {
   void byteBuddyProxyListensToFeature() {
     // Given:
     Supplier<String> proxy = ByteBuddyProxyFactory.proxyFor(Features.F1, Supplier.class, sayHello, sayWorld, featureManager);
-    // When:
-    featureManager.setFeatureState(new FeatureState(Features.F1, true));
     // Then:
+    featureManager.setFeatureState(new FeatureState(Features.F1, true));
     assertEquals("Hello", proxy.get());
     featureManager.setFeatureState(new FeatureState(Features.F1, false));
+    assertEquals("World", proxy.get());
+  }
+
+  @Test
+  void byteBuddyPassiveProxyListensToFeatureOnlyWhenUpdated() {
+    // Given:
+    Supplier<String> proxy = ByteBuddyProxyFactory.passiveProxyFor(Features.F1, Supplier.class, sayHello, sayWorld, featureManager);
+    featureManager.setFeatureState(new FeatureState(Features.F1, false));
+    assertEquals("Hello", proxy.get()); // inactive state is ignored
+    // When:
+    TogglzSwitchable.update(proxy);
+    // Then:
     assertEquals("World", proxy.get());
   }
 

--- a/core/src/test/java/org/togglz/core/proxy/ByteBuddyProxyFactoryTest.java
+++ b/core/src/test/java/org/togglz/core/proxy/ByteBuddyProxyFactoryTest.java
@@ -35,6 +35,17 @@ class ByteBuddyProxyFactoryTest {
   }
 
   @Test
+  void byteBuddyProxyHasNiceName() {
+    // Given:
+    Class<Speaker> interfaceClass = Speaker.class;
+    // When:
+    Supplier<String> proxy = ByteBuddyProxyFactory.proxyFor(Features.F1, interfaceClass, sayHello, sayWorld, featureManager);
+    // Then:
+    assertTrue(proxy.getClass().getName().startsWith("org.togglz.core.proxy.ByteBuddyProxyFactoryTest$Speaker$togglz$"));
+  }
+
+
+  @Test
   void byteBuddyProxyListensToFeature() {
     // Given:
     Supplier<String> proxy = ByteBuddyProxyFactory.proxyFor(Features.F1, Supplier.class, sayHello, sayWorld, featureManager);

--- a/core/src/test/java/org/togglz/core/proxy/ByteBuddyProxyFactoryTest.java
+++ b/core/src/test/java/org/togglz/core/proxy/ByteBuddyProxyFactoryTest.java
@@ -1,0 +1,53 @@
+package org.togglz.core.proxy;
+
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.togglz.core.Feature;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.manager.FeatureManagerBuilder;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.repository.mem.InMemoryStateRepository;
+import org.togglz.core.user.NoOpUserProvider;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ByteBuddyProxyFactoryTest {
+
+  private static final Speaker sayHello = () -> "Hello";
+  private static final Speaker sayWorld = () -> "World";
+  private FeatureManager featureManager;
+
+  public interface Speaker extends Supplier<String> {
+    default String get() { return getName(); }
+    String getName();
+  }
+
+  @BeforeEach
+  void before() {
+    featureManager = new FeatureManagerBuilder()
+      .featureEnum(ByteBuddyProxyFactoryTest.Features.class)
+      .stateRepository(new InMemoryStateRepository())
+      .userProvider(new NoOpUserProvider())
+      .build();
+
+    featureManager.setFeatureState(new FeatureState(Features.F1, true));
+  }
+
+  @Test
+  void byteBuddyProxyListensToFeature() {
+    // Given:
+    Supplier<String> proxy = ByteBuddyProxyFactory.proxyFor(Features.F1, Supplier.class, sayHello, sayWorld, featureManager);
+    // When:
+    featureManager.setFeatureState(new FeatureState(Features.F1, true));
+    // Then:
+    assertEquals("Hello", proxy.get());
+    featureManager.setFeatureState(new FeatureState(Features.F1, false));
+    assertEquals("World", proxy.get());
+  }
+
+  private enum Features implements Feature {
+    F1
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -400,6 +400,12 @@
         <scope>provided</scope>
       </dependency>
 
+      <dependency>
+        <!-- Used by proxy generation -->
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>1.11.0</version>
+      </dependency>
 
       <dependency>
         <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
See #572 

I'm not sure if the public method signatures are very "nice" but I am not prepared to write a fluent interface over another fluent interface! 

There may well be ways to break this with esoteric interfaces or A/B implementations.

Perf numbers on my laptop (hence not representative of anything bu the most general case) are

```
ByteBuddyProxyBenchmark.activeProxy                thrpt   10   239315.306 ± 15888.226  ops/s
ByteBuddyProxyBenchmark.directCall                 thrpt   10  1550241.064 ± 75722.542  ops/s
ByteBuddyProxyBenchmark.handCodedSwitch            thrpt   10   228647.953 ± 16606.360  ops/s
ByteBuddyProxyBenchmark.handCodedTogglzSwitchable  thrpt   10   194226.042 ± 11958.108  ops/s
ByteBuddyProxyBenchmark.passiveProxy               thrpt   10  1123894.708 ± 29480.899  ops/s
JdkProxyBenchmark.proxyCall                        thrpt   10   153486.839 ±  1507.588  ops/s
```

Which shows a few interesting things:
1. activeProxy is faster than both hand-coded proxies!
2. passiveProxy is in the same ballpark as directCall
