### PR TITLE
Changed the validateCSRFToken method to default to fail

### DIFF
--- a/console/src/main/java/org/togglz/console/handlers/edit/EditPageHandler.java
+++ b/console/src/main/java/org/togglz/console/handlers/edit/EditPageHandler.java
@@ -92,14 +92,16 @@ public class EditPageHandler extends RequestHandlerBase {
     }
 
     private boolean validateCSRFToken(RequestEvent event) {
-        boolean isValid = true;
+        boolean isValid = false;
         if (event.getRequestContext().isValidateCSRFToken()) {
             for (CSRFTokenValidator validator : Services.get(CSRFTokenValidator.class)) {
-                if (!validator.isTokenValid(event.getRequest())) {
-                    isValid = false;
+                if (validator.isTokenValid(event.getRequest())) {
+                    isValid = true;
                     break;
                 }
             }
+        } else {
+            isValid = true;
         }
         return isValid;
     }


### PR DESCRIPTION
 rather than default to succeed CSRF validation. I'm not aware of any way to exploit this, but it is always better to fail safe.