### PR TITLE
Feature: flags for java platform

### DIFF
--- a/spring-security/src/main/java/org/togglz/spring/security/SpringSecurityUserProvider.java
+++ b/spring-security/src/main/java/org/togglz/spring/security/SpringSecurityUserProvider.java
@@ -43,7 +43,7 @@ public class SpringSecurityUserProvider implements UserProvider {
         return user;
     }
 
-    private boolean isFeatureAdmin(Set<String> authorities) {
+    protected boolean isFeatureAdmin(Set<String> authorities) {
         return featureAdminAuthority != null && authorities.contains(featureAdminAuthority);
     }
 


### PR DESCRIPTION
Change SpringSecurityUserProvider.isFeatureAdmin from private to protected so that it can be called outside the class for external usages