### PR TITLE
fix label creation for annotation feature group when no @Label exists

### DIFF
--- a/core/src/main/java/org/togglz/core/metadata/enums/AnnotationFeatureGroup.java
+++ b/core/src/main/java/org/togglz/core/metadata/enums/AnnotationFeatureGroup.java
@@ -23,7 +23,7 @@ public class AnnotationFeatureGroup implements FeatureGroup {
         if (labelAnnotation != null) {
             label = labelAnnotation.value();
         } else {
-            label = groupAnnotation.getClass().getSimpleName();
+            label = groupAnnotation.getSimpleName();
         }
     }
 

--- a/core/src/test/java/org/togglz/core/metadata/enums/AnnotationFeatureGroupTest.java
+++ b/core/src/test/java/org/togglz/core/metadata/enums/AnnotationFeatureGroupTest.java
@@ -31,7 +31,14 @@ class AnnotationFeatureGroupTest {
     private @interface ClassLevelGroup {
     }
 
+    @org.togglz.core.annotation.FeatureGroup
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface ClassLevelUnlabeledGroup {
+    }
+
     @ClassLevelGroup
+    @ClassLevelUnlabeledGroup
     private enum TestFeatures implements Feature {
 
         @FieldLevelGroup
@@ -60,6 +67,15 @@ class AnnotationFeatureGroupTest {
 
         assertNotNull(result);
         assertEquals(CLASS_LEVEL_GROUP_LABEL, result.getLabel());
+        assertTrue(result.contains(TestFeatures.FEATURE));
+    }
+
+    @Test
+    void buildWillReturnFeatureGroupWhenFeatureGroupAnnotationIsMissingLabelAnnotation() {
+        FeatureGroup result = AnnotationFeatureGroup.build(ClassLevelUnlabeledGroup.class);
+
+        assertNotNull(result);
+        assertEquals("ClassLevelUnlabeledGroup", result.getLabel());
         assertTrue(result.contains(TestFeatures.FEATURE));
     }
 }


### PR DESCRIPTION
hey, I've found a bug when having a feature group with no Label-Annotation.
When having a FeatureGroup like the following:

```
 @FeatureGroup
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @interface ClassLevelUnlabeledGroup {
 }
```
The label was always "Class"

The behavior can be reproduced by the test i added.