### PR TITLE
bump gmavenplus-plugin to 1.13.1 fixes #625

### DIFF
--- a/slack/pom.xml
+++ b/slack/pom.xml
@@ -68,14 +68,14 @@
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
-        <version>1.0</version>
+        <version>1.13.1</version>
         <executions>
           <execution>
             <goals>
               <goal>generateStubs</goal>
               <goal>compile</goal>
-              <goal>testGenerateStubs</goal>
-              <goal>testCompile</goal>
+              <goal>generateTestStubs</goal>
+              <goal>compileTests</goal>
             </goals>
           </execution>
         </executions>

--- a/spock/pom.xml
+++ b/spock/pom.xml
@@ -28,7 +28,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.12.1</version>
+                <version>1.13.1</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
the plugin's goals seem to have been renamed some versions ago.
Tests run fine, no further manual tests done.