### PR TITLE
make spring-boot-starter compatible with spring-boot 2.6x+ (and break…

### DIFF
--- a/spring-boot/starter/pom.xml
+++ b/spring-boot/starter/pom.xml
@@ -13,7 +13,7 @@
   <description>Togglz - Spring Boot Starter</description>
 
   <properties>
-    <spring-boot.version>2.4.1</spring-boot.version>
+    <spring-boot.version>2.6.2</spring-boot.version>
   </properties>
 
   <dependencyManagement>
@@ -141,13 +141,11 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-commons</artifactId>
-      <version>1.7.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.8.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/spring-boot/starter/src/main/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzManagementContextConfiguration.java
+++ b/spring-boot/starter/src/main/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzManagementContextConfiguration.java
@@ -59,7 +59,7 @@ public class TogglzManagementContextConfiguration {
 
         @Override
         protected String getContextPath() {
-            return managementServerProperties.getServlet().getContextPath();
+            return managementServerProperties.getBasePath();
         }
     }
 

--- a/spring-boot/starter/src/test/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzManagementContextConfigurationTest.java
+++ b/spring-boot/starter/src/test/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzManagementContextConfigurationTest.java
@@ -40,7 +40,7 @@ public class TogglzManagementContextConfigurationTest extends BaseTest {
         // With TogglzManagementContextConfiguration responsible for creating the admin console servlet registration bean,
         // if a custom management context path is provided it should be used as prefix.
         contextRunnerWithFeatureProviderConfig()
-            .withPropertyValues("management.server.servlet.context-path: /manage")
+            .withPropertyValues("management.server.base-path: /manage")
             .run((context) -> assertThat(getUrlMappings(context)).contains("/manage/togglz-console/*"));
     }
 


### PR DESCRIPTION
… with < 2.4.x) by adopting the new property key for management server base paths / prefixes. (management.server.servlet.context-path -> management.server.base-path)

Also the build didn't run any more test, as it seems, see:
https://github.com/togglz/togglz/runs/4324826674?check_suite_focus=true#step:4:3788

I removed the JUnit version numbers from the module to inherit from the parent pom and the tests work fine again now.

Would be great if we could have a release afterwards to make toggle work with spring-boot 2.6.