### PR TITLE
enforce to run existing unit tests to avoid green builds for possibly broken, but not executed, tests

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -69,6 +69,14 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- No unit tests in this module so far. You should drop this plugin section when you add some :) -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -12,6 +12,19 @@
   <name>Togglz - CDI integration</name>
   <description>Togglz - CDI integration</description>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- FIXME There are actually tests that should run but just don't ATM -->
+          <failIfNoTests>false</failIfNoTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
 
     <dependency>

--- a/cloud-datastore/pom.xml
+++ b/cloud-datastore/pom.xml
@@ -16,6 +16,19 @@
         <gcloud.version>0.8.0-beta</gcloud.version>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- No unit tests in this module so far. You should drop this plugin section when you add some :) -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
 
         <dependency>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -82,12 +82,15 @@
       <artifactId>commons-collections4</artifactId>
       <version>4.4</version>
     </dependency>
-      <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-params</artifactId>
-          <version>5.8.2</version>
-          <scope>test</scope>
-      </dependency>
-
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/dynamodb/pom.xml
+++ b/dynamodb/pom.xml
@@ -134,7 +134,6 @@
                 </executions>
             </plugin>
 
-
             <plugin>
                 <groupId>com.jcabi</groupId>
                 <artifactId>jcabi-dynamodb-maven-plugin</artifactId>
@@ -166,9 +165,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <excludes>
-                        <exclude>**/*IT.java</exclude>
-                    </excludes>
+                    <!-- No unit tests in this module so far. You should drop this plugin section when you add some :) -->
+                    <skip>true</skip>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,8 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+              <!-- some mudules don't find the existing tests, we should break the build in that case -->
+              <failIfNoTests>true</failIfNoTests>
               <systemPropertyVariables>
                 <arquillian.launch>wildfly-managed</arquillian.launch>
               </systemPropertyVariables>

--- a/slf4j/pom.xml
+++ b/slf4j/pom.xml
@@ -12,6 +12,19 @@
   <name>Togglz - SLF4J integration</name>
   <description>Togglz - SLF4J integration</description>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+            <!-- No unit tests in this module so far. You should drop this plugin section when you add some :) -->
+            <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
 
     <dependency>

--- a/test-harness/pom.xml
+++ b/test-harness/pom.xml
@@ -73,6 +73,14 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+            <!-- No unit tests in this module so far. You should drop this plugin section when you add some :) -->
+            <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <useDefaultManifestFile>true</useDefaultManifestFile>


### PR DESCRIPTION
Hi @bennetelli
I played a bit more with the project and noticed, already last time, that some unit tests are not executed.

This PR will break the build if that should happen again. It also fixes this issue for the console module.

It also uncovers the problem for the CDI module, I was unable to fix it though. Should I open an issue for that?

I could do the same work for the ITs / failsafe-plugin if you are merging this PR.