### PR TITLE
add needed jvm opts to run cassandra tests under java11+; see #598

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -51,6 +51,8 @@
             <artifactId>curator-test</artifactId>
             <version>5.2.0</version>
         </dependency>
+        <!--        brauchen wir hier hier nur die api? nur -simple? nur logback?  nur provided? -->
+        <!--        https://repo1.maven.org/maven2/org/slf4j/ -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -15,6 +15,41 @@
         <astyanax.version>3.9.0</astyanax.version>
     </properties>
 
+    <profiles>
+        <profile>
+            <!-- adds JVM options to java 11+ builds as described in
+            https://support.datastax.com/s/article/ERROR-FATAL-Cassandra-is-unable-to-access-required-classes-This-usually-means-it-has-been
+            to allow successful test runs -->
+            <id>surefire-java11</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>
+                                -Djdk.attach.allowAttachSelf=true
+                                --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+                                --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+                                --add-exports java.base/sun.nio.ch=ALL-UNNAMED
+                                --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED
+                                --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED
+                                --add-exports java.sql/java.sql=ALL-UNNAMED --add-opens java.base/java.lang.module=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens java.base/jdk.internal.ref=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.math=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.module=ALL-UNNAMED --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED
+                                --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+                            </argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>org.togglz</groupId>

--- a/dynamodb/pom.xml
+++ b/dynamodb/pom.xml
@@ -11,7 +11,6 @@
     <name>Togglz - DynamoDB integration</name>
     <description>Togglz - DynamoDB integration</description>
 
-
     <dependencies>
         <dependency>
             <groupId>org.togglz</groupId>
@@ -27,9 +26,8 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.35</version>
         </dependency>
-
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -42,14 +40,6 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.35</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/zookeeper/pom.xml
+++ b/zookeeper/pom.xml
@@ -53,12 +53,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.35</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Hi @bennetelli , togglz does build properly with this on my machine.
If you'd change fail-fast: true to false I think you should see the java 8 and 11 builds pass in a matrix build.