### PR TITLE
move assertJ to test scope

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,6 +23,7 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>3.22.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
build works fine with assertJ in test scope, so I assume the `<scope>test</scope>` was left out by misstake?