### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-# Togglz
-![Build Status](https://github.com/togglz/togglz/workflows/Java%20CI/badge.svg)
+![togglz logo](https://www.togglz.org/images/togglz-logo.png)
+
+[![GitHub CI](https://github.com/togglz/togglz/actions/workflows/maven.yml/badge.svg)](https://github.com/togglz/togglz/actions/workflows/maven.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/org.togglz/togglz-core.svg)](https://maven-badges.herokuapp.com/maven-central/org.togglz/togglz-core)
 ![License](https://img.shields.io/github/license/togglz/togglz)
 
+
+<br><br>
 Togglz is an implementation of the Feature Toggles pattern for Java. Feature Toggles are a very common agile development practices in the context of continuous deployment and delivery. The basic idea is to associate a toggle with each new feature you are working on. This allows you to enable or disable these features at application runtime, even for individual users.
 
-Want to learn more? Have a look at an usage example or check the quickstart guide, see http://www.togglz.org/ 
-
-## Contributors
-
-This project exists thanks to all the people who contribute. 
-<a href="../../graphs/contributors"><img src="https://opencollective.com/togglz/contributors.svg?width=890" /></a>
+Want to learn more? Have a look at an usage example or check the quickstart guide, see https://www.togglz.org/ 


### PR DESCRIPTION
http -> https link
drop contributors section, it's integrated on the startpage already and openCollective page is inactive anyways
add logo
let CI badge link point to actions tab

(not sure about the logo link, the png could go to the repo itself as well in favour of using the togglz.org/ link)