### PR TITLE
Leave inner space of parameter values unchanged

### DIFF
--- a/spring-boot/starter/src/main/java/org/togglz/spring/boot/actuate/TogglzEndpoint.java
+++ b/spring-boot/starter/src/main/java/org/togglz/spring/boot/actuate/TogglzEndpoint.java
@@ -29,14 +29,10 @@ import org.togglz.core.repository.FeatureState;
 import org.togglz.core.util.Preconditions;
 import org.togglz.spring.boot.actuate.autoconfigure.TogglzFeature;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.springframework.util.StringUtils.commaDelimitedListToSet;
-import static org.springframework.util.StringUtils.trimAllWhitespace;
 
 /**
  * Spring Boot 2+ {@link Endpoint} to expose Togglz info as an actuator endpoint.
@@ -126,12 +122,12 @@ public class TogglzEndpoint {
     }
 
     private String[] toParameterKeyValue(String parameterString) {
-        String[] parameterKeyValue = trimAllWhitespace(parameterString).split(PARAMETER_VALUE_SEPARATOR);
+        String[] parameterKeyValue = parameterString.split(PARAMETER_VALUE_SEPARATOR);
 
         Preconditions.checkArgument(
                 parameterKeyValue.length == 2,
                 "Illegal parameter key/value format: %s", parameterString);
 
-        return parameterKeyValue;
+        return Arrays.stream(parameterKeyValue).map(String::trim).toArray(String[]::new);
     }
 }

--- a/spring-boot/starter/src/test/java/org/togglz/spring/boot/actuate/TogglzEndpointTest.java
+++ b/spring-boot/starter/src/test/java/org/togglz/spring/boot/actuate/TogglzEndpointTest.java
@@ -158,7 +158,7 @@ public class TogglzEndpointTest extends BaseTest {
                 .run((context) -> {
                     // Given
                     TogglzEndpoint endpoint = context.getBean(TogglzEndpoint.class);
-                    String parametersString = "param1 = 10, param2 = 20";
+                    String parametersString = "param1 = 10, param2 = 20 30";
 
                     // When
                     final TogglzFeature togglzFeature = endpoint.setFeatureState(
@@ -167,7 +167,7 @@ public class TogglzEndpointTest extends BaseTest {
                     // Then
                     Map<String, String> params = togglzFeature.getParams();
                     assertEquals("10", params.get("param1"));
-                    assertEquals("20", params.get("param2"));
+                    assertEquals("20 30", params.get("param2"));
                 });
     }
 

--- a/spring-boot/starter/src/test/java/org/togglz/spring/boot/actuate/TogglzEndpointTest.java
+++ b/spring-boot/starter/src/test/java/org/togglz/spring/boot/actuate/TogglzEndpointTest.java
@@ -158,7 +158,7 @@ public class TogglzEndpointTest extends BaseTest {
                 .run((context) -> {
                     // Given
                     TogglzEndpoint endpoint = context.getBean(TogglzEndpoint.class);
-                    String parametersString = "param1 = 10, param2 = 20 30";
+                    String parametersString = "param1 = 10, param2 = 20 30, param3 = 40";
 
                     // When
                     final TogglzFeature togglzFeature = endpoint.setFeatureState(
@@ -168,6 +168,7 @@ public class TogglzEndpointTest extends BaseTest {
                     Map<String, String> params = togglzFeature.getParams();
                     assertEquals("10", params.get("param1"));
                     assertEquals("20 30", params.get("param2"));
+                    assertEquals("40", params.get("param3"));
                 });
     }
 


### PR DESCRIPTION
Having inner space in parameters untouched allows using space as separator inside multi-valued parameters. Good example could be ClientIpActivationStrategy where one can provide a list of IPs (space separated) as value of parameter.