### PR TITLE
drop unneeded config line

### DIFF
--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -53,7 +53,6 @@ class MyTogglzConfiguration {
                 .build()
 
         StaticFeatureManagerProvider.setFeatureManager(featureManager)
-        FeatureManagerProvider.featureMgr = featureManager
         return featureManager
     }
 


### PR DESCRIPTION
I don't see what this config line is supposed to do, it tries to assign a field of an interface and does not work as it does not exist after all.