### PR TITLE
Fix JavaScript encoding issue

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -97,5 +97,10 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+      <artifactId>owasp-java-html-sanitizer</artifactId>
+      <version>20220608.1</version>
+    </dependency>
   </dependencies>
 </project>

--- a/console/src/main/java/org/togglz/console/handlers/index/IndexPageHandler.java
+++ b/console/src/main/java/org/togglz/console/handlers/index/IndexPageHandler.java
@@ -59,7 +59,9 @@ public class IndexPageHandler extends RequestHandlerBase {
         model.put("tabView", tabView);
 
         String template = getResourceAsString("index.html");
-        String content = new Engine().transform(template, model);
+        Engine engine = new Engine();
+        engine.registerNamedRenderer(new SanitizeHtmlRenderer());
+        String content = engine.transform(template, model);
         writeResponse(event, content);
     }
 }

--- a/console/src/main/java/org/togglz/console/handlers/index/SanitizeHtmlRenderer.java
+++ b/console/src/main/java/org/togglz/console/handlers/index/SanitizeHtmlRenderer.java
@@ -1,0 +1,45 @@
+package org.togglz.console.handlers.index;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
+
+import com.floreysoft.jmte.NamedRenderer;
+import com.floreysoft.jmte.RenderFormatInfo;
+
+public class SanitizeHtmlRenderer implements NamedRenderer {
+
+    @Override
+    public RenderFormatInfo getFormatInfo() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return "sanitizeHtml";
+    }
+
+    @Override
+    public Class<?>[] getSupportedClasses() {
+        return new Class<?>[] { String.class };
+    }
+
+    @Override
+    public String render(Object o, String format, Locale locale, Map<String, Object> model) {
+        if (o instanceof String) {
+            String html = (String) o;
+
+            PolicyFactory policy = new HtmlPolicyBuilder()
+                    .allowElements("a")
+                    .allowUrlProtocols("https")
+                    .allowAttributes("href").onElements("a")
+                    .requireRelNofollowOnLinks()
+                    .toFactory();
+
+            return policy.sanitize(html);
+        }
+        return null;
+    }
+}

--- a/console/src/main/java/org/togglz/console/model/ParameterModel.java
+++ b/console/src/main/java/org/togglz/console/model/ParameterModel.java
@@ -2,7 +2,6 @@ package org.togglz.console.model;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.owasp.encoder.Encode;
 import org.togglz.core.activation.Parameter;
 import org.togglz.core.repository.FeatureState;
 import org.togglz.core.util.Strings;
@@ -28,7 +27,8 @@ public class ParameterModel {
     }
 
     public void readValueFrom(HttpServletRequest request) {
-        this.value = Encode.forHtml(request.getParameter(getInputId()));
+        this.value = request.getParameter(getInputId());
+
     }
 
     public String getValidationError() {

--- a/console/src/main/resources/org/togglz/console/index.html
+++ b/console/src/main/resources/org/togglz/console/index.html
@@ -60,7 +60,7 @@
                   <ul class="params">
                   ${foreach feature.strategy.parameters param}
                     ${if param.hasValue}
-                      <li>${param.label}: ${param.value}</li>
+                      <li>${param.label}: ${param.value;sanitizeHtml}</li>
                     ${end}
                   ${end}
                   </ul>


### PR DESCRIPTION
Actually fixes https://github.com/togglz/togglz/issues/849

The issue was: we encoded the JS script before saving it, therefore making it corrupted (& became &amp;, etc.).

Now, we store the raw JS sent by the client in DB, and only when DISPLAYING the value, we sanitize it to prevent XSS.

Please tell me if there's another XSS issue somewhere, because apart from the main page, I didn't think of anything else ;)