### PR TITLE
Reduce allocations from DefaultMapSerializer

### DIFF
--- a/core/src/main/java/org/togglz/core/repository/util/DefaultMapSerializer.java
+++ b/core/src/main/java/org/togglz/core/repository/util/DefaultMapSerializer.java
@@ -14,7 +14,7 @@ import java.util.Properties;
 
 /**
  * This converter is able to convert string maps to simple strings and vice versa.
- * 
+ *
  * @author Christian Kaltepoth
  */
 public class DefaultMapSerializer implements MapSerializer {
@@ -59,15 +59,14 @@ public class DefaultMapSerializer implements MapSerializer {
         return new DefaultMapSerializer(true, lineSeparator);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.togglz.core.util.MapSerializer#convertToString(java.util.Map)
-     */
     @Override
     public String serialize(Map<String, String> map) {
 
         try {
+
+            if (map.isEmpty()) {
+                return "";
+            }
 
             // the format is based on the properties output format
             Properties props = new Properties();
@@ -113,11 +112,6 @@ public class DefaultMapSerializer implements MapSerializer {
 
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.togglz.core.util.MapSerializer#convertFromString(java.lang.String)
-     */
     @Override
     public Map<String, String> deserialize(String s) {
 
@@ -125,10 +119,12 @@ public class DefaultMapSerializer implements MapSerializer {
 
             String input = multiline ? s : s.replace('&', '\n');
 
-            Properties props = new Properties();
-            if (s != null) {
-                props.load(new StringReader(input));
+            if (input == null || input.isEmpty()) {
+                return Collections.emptyMap();
             }
+
+            Properties props = new Properties();
+            props.load(new StringReader(input));
 
             LinkedHashMap<String, String> result = new LinkedHashMap<>();
             for (Entry<Object, Object> entry : props.entrySet()) {

--- a/core/src/test/java/org/togglz/core/repository/util/DefaultMapSerializerTest.java
+++ b/core/src/test/java/org/togglz/core/repository/util/DefaultMapSerializerTest.java
@@ -6,6 +6,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultMapSerializerTest {
@@ -141,4 +143,47 @@ public class DefaultMapSerializerTest {
 
         assertEquals("param1=value1%param2=value2", data);
     }
+
+    @Test
+    public void emptyMapSerializedToEmptyString() {
+
+        DefaultMapSerializer serializer = DefaultMapSerializer.multiline();
+
+        Map<String, String> input = new HashMap<>();
+
+        String data = serializer.serialize(input);
+
+        assertEquals("", data);
+    }
+
+    @Test
+    public void nullMapSerializeThrowsException() {
+
+        DefaultMapSerializer serializer = DefaultMapSerializer.multiline();
+
+        assertThrows(NullPointerException.class, () -> serializer.serialize(null));
+    }
+
+    @Test
+    public void emptyStringDeserializedToEmptyMap() {
+
+        DefaultMapSerializer serializer = DefaultMapSerializer.multiline();
+
+        Map<String, String> data = serializer.deserialize("");
+
+        assertNotNull(data);
+        assertTrue(data.isEmpty());
+    }
+
+    @Test
+    public void nullStringDeserializedToEmptyMap() {
+
+        DefaultMapSerializer serializer = DefaultMapSerializer.multiline();
+
+        Map<String, String> data = serializer.deserialize(null);
+
+        assertNotNull(data);
+        assertTrue(data.isEmpty());
+    }
+
 }


### PR DESCRIPTION
Hi,

I've been profiling some test suites lately and noticed that Togglz does a small, but noticeable, amount of allocations when reloading feature states before & after tests:

E.g. see the following excerpts. Overall, all of the different frames account for ~1% of allocations.
<img width="909" alt="image" src="https://user-images.githubusercontent.com/6304496/204210224-ab23b548-fd6c-4311-b0c6-13aace4c85ba.png">
<img width="909" alt="image" src="https://user-images.githubusercontent.com/6304496/204210541-7746c5ea-819e-45bc-856f-3e2500478941.png">

The unfortunate bit here is that the work in `DefaultMapSerializer` could be largely skipped if the Map is empty (which it is in most default cases). So this PR checks for emptiness on (de-)serialization to save some work & allocations.

Let me know what you think.
Cheers,
Christoph