### PR TITLE
Reduce overhead of TogglzTestExecutionListener

### DIFF
--- a/core/src/main/java/org/togglz/core/repository/FeatureState.java
+++ b/core/src/main/java/org/togglz/core/repository/FeatureState.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
 import org.togglz.core.Feature;
@@ -210,6 +211,41 @@ public class FeatureState implements Serializable {
      */
     public Map<String, String> getParameterMap() {
         return Collections.unmodifiableMap(this.parameters);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FeatureState that = (FeatureState) o;
+
+        if (this.enabled != that.enabled) {
+            return false;
+        }
+        if (!this.feature.equals(that.feature)) {
+            return false;
+        }
+        if (!Objects.equals(this.strategyId, that.strategyId)) {
+            return false;
+        }
+        if (this.parameters.size() != that.parameters.size()) {
+            return false;
+        }
+        return this.parameters.equals(that.parameters);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = this.feature.hashCode();
+        result = 31 * result + Boolean.hashCode(this.enabled);
+        result = 31 * result + (this.strategyId != null ? this.strategyId.hashCode() : 0);
+        result = 31 * result + this.parameters.hashCode();
+        return result;
     }
 
     /**

--- a/core/src/test/java/org/togglz/core/repository/FeatureStateTest.java
+++ b/core/src/test/java/org/togglz/core/repository/FeatureStateTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FeatureStateTest {
@@ -52,7 +53,33 @@ class FeatureStateTest {
         assertEquals(state.getUsers().get(2), "tester");
     }
 
+    @Test
+    void testEquals() {
+
+        FeatureState state = new FeatureState(Features.FEATURE1);
+        FeatureState copy = state.copy();
+        assertEquals(state, copy);
+
+        // Different feature
+        assertNotEquals(state, new FeatureState(Features.FEATURE2));
+
+        // Different enabled state
+        state.setEnabled(true);
+        assertNotEquals(state, copy);
+
+        // Different strategy
+        copy = state.copy();
+        state.setStrategyId("Strategy");
+        assertNotEquals(state, copy);
+
+        // Different parameters
+        copy = state.copy();
+        state.setParameter("key", "value");
+        assertNotEquals(state, copy);
+    }
+
     private enum Features implements Feature {
-        FEATURE1
+        FEATURE1,
+        FEATURE2
     }
 }

--- a/core/src/test/java/org/togglz/core/repository/mem/InMemoryStateRepositoryTest.java
+++ b/core/src/test/java/org/togglz/core/repository/mem/InMemoryStateRepositoryTest.java
@@ -6,7 +6,7 @@ import org.togglz.core.Feature;
 import org.togglz.core.repository.FeatureState;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 class InMemoryStateRepositoryTest {
 
@@ -22,7 +22,7 @@ class InMemoryStateRepositoryTest {
         FeatureState featureState = createDisabledFeatureState();
         repository.setFeatureState(featureState);
         FeatureState featureStateFromRepo = repository.getFeatureState(MyFeature.FEATURE1);
-        assertNotEquals(featureState, featureStateFromRepo);
+        assertNotSame(featureState, featureStateFromRepo);
     }
 
     @Test

--- a/spring-core/src/main/java/org/togglz/spring/test/TogglzTestExecutionListener.java
+++ b/spring-core/src/main/java/org/togglz/spring/test/TogglzTestExecutionListener.java
@@ -41,6 +41,9 @@ public class TogglzTestExecutionListener extends AbstractTestExecutionListener {
 		for (Feature feature : manager.getFeatures()) {
 			FeatureState defaultFeatureState = manager.getMetaData(feature).getDefaultFeatureState();
 			FeatureState state = manager.getFeatureState(feature);
+			if (defaultFeatureState.equals(state)) {
+				continue;
+			}
 			if (defaultFeatureState.isEnabled()) {
 				state.enable();
 			}


### PR DESCRIPTION
Hi,

I've noticed that our test-suite spends around ~3-4% of CPU cycles just inside `TogglzTestExecutionListener`.

<img width="827" alt="image" src="https://user-images.githubusercontent.com/6304496/208184491-f20d08cc-1708-4231-b6e3-79866cfb5da1.png">


The unfortunate bit here is that we don't even customize the feature flags in the majority of cases and deal with the default state. It seems that we could skip setting the feature flag state in those cases - which resorts to the JDBC implementation for us - and avoid the corresponding overhead. The additional benefit in our case is that the `CachingStateRepository` will have more cache hits and avoid the reading overhead from the database as well.

Let me know what you think.

Cheers,
Christoph