### PR TITLE
togglz-servlet web-fragment namespace value is not compliant with 

### DIFF
--- a/console/src/main/resources/META-INF/web-fragment.xml
+++ b/console/src/main/resources/META-INF/web-fragment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-fragment version="6.0" xmlns="https://jakarta.ee/xml/ns/jakartaee/"
+<web-fragment version="6.0" xmlns="https://jakarta.ee/xml/ns/jakartaee"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee/ https://jakarta.ee/xml/ns/jakartaee/web-fragment_6_0.xsd">
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-fragment_6_0.xsd">
 
   <name>togglz_console</name>
 

--- a/servlet/src/main/resources/META-INF/web-fragment.xml
+++ b/servlet/src/main/resources/META-INF/web-fragment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-fragment version="6.0" xmlns="https://jakarta.ee/xml/ns/jakartaee/"
+<web-fragment version="6.0" xmlns="https://jakarta.ee/xml/ns/jakartaee"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee/ https://jakarta.ee/xml/ns/jakartaee/web-fragment_6_0.xsd">
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-fragment_6_0.xsd">
 
   <name>togglz</name>
 


### PR DESCRIPTION
The value of the namespace of META-INF/web-fragment.xml contains a trailing "/" value. 

This is not compliant with
https://jakarta.ee/xml/ns/jakartaee/web-fragment_6_0.xsd

and will result in an error during application bootstrap if the application server (in my case payara 6) does xml validation. 

To resolve this issue, i changed the value to "https://jakarta.ee/xml/ns/jakartaee" without the trailing "/"