### PR TITLE
Remove parameters with empty values.

### DIFF
--- a/core/src/main/java/org/togglz/core/repository/FeatureState.java
+++ b/core/src/main/java/org/togglz/core/repository/FeatureState.java
@@ -122,10 +122,9 @@ public class FeatureState implements Serializable {
      * Sets a new value for the given parameter.
      */
     public FeatureState setParameter(String name, String value) {
-        if (value != null) {
+        if (value != null && !value.isEmpty()) {
             this.parameters.put(name, value);
-        }
-        else {
+        } else {
             this.parameters.remove(name);
         }
         return this;


### PR DESCRIPTION
As far I can see, there is currently no possibility to remove parameter, when it was previously assigned. This change fixes that.