### PR TITLE
Provide spring boot starter for (S3) repository auto configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -435,6 +435,12 @@
             </dependency>
 
             <dependency>
+              <groupId>org.togglz</groupId>
+              <artifactId>togglz-amazon-s3</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.togglz</groupId>
                 <artifactId>togglz-testing</artifactId>
                 <version>${project.version}</version>

--- a/spring-boot/autoconfigure/pom.xml
+++ b/spring-boot/autoconfigure/pom.xml
@@ -103,6 +103,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.togglz</groupId>
+      <artifactId>togglz-amazon-s3</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>

--- a/spring-boot/autoconfigure/src/main/java/org/togglz/spring/boot/repository/TogglzStateRepositoryAutoConfiguration.java
+++ b/spring-boot/autoconfigure/src/main/java/org/togglz/spring/boot/repository/TogglzStateRepositoryAutoConfiguration.java
@@ -1,0 +1,55 @@
+package org.togglz.spring.boot.repository;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.togglz.core.repository.StateRepository;
+import org.togglz.core.repository.cache.CachingStateRepository;
+import org.togglz.s3.S3StateRepository;
+import org.togglz.spring.boot.actuate.autoconfigure.TogglzAutoConfiguration;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@AutoConfiguration(before = TogglzAutoConfiguration.class)
+@EnableConfigurationProperties(TogglzStateRepositoryConfigurationProperties.class)
+public class TogglzStateRepositoryAutoConfiguration {
+
+    private final TogglzStateRepositoryConfigurationProperties configurationProperties;
+
+    public TogglzStateRepositoryAutoConfiguration(TogglzStateRepositoryConfigurationProperties configurationProperties) {
+        this.configurationProperties = configurationProperties;
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass({S3StateRepository.class, S3Client.class})
+    @ConditionalOnProperty(prefix = "togglz.state-repository.s3", name = "bucket-name")
+    public class S3StateRepositoryConfiguration {
+
+        @ConditionalOnMissingBean
+        @Bean
+        public S3Client s3Client() {
+            return S3Client.create();
+        }
+
+        @ConditionalOnMissingBean
+        @Bean
+        public StateRepository stateRepository(S3Client s3Client) {
+            StateRepository s3StateRepository = S3StateRepository
+                    .newBuilder(s3Client, configurationProperties.getS3().getBucketName())
+                    .build();
+
+            return wrapWithCache(s3StateRepository);
+        }
+    }
+
+    private StateRepository wrapWithCache(StateRepository delegate) {
+        if (configurationProperties.getCache().isEnabled()) {
+            return new CachingStateRepository(delegate, configurationProperties.getCache().getTimeToLive().toMillis());
+        } else {
+            return delegate;
+        }
+    }
+}

--- a/spring-boot/autoconfigure/src/main/java/org/togglz/spring/boot/repository/TogglzStateRepositoryConfigurationProperties.java
+++ b/spring-boot/autoconfigure/src/main/java/org/togglz/spring/boot/repository/TogglzStateRepositoryConfigurationProperties.java
@@ -1,0 +1,58 @@
+package org.togglz.spring.boot.repository;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = "togglz.state-repository")
+public class TogglzStateRepositoryConfigurationProperties {
+
+    private final S3 s3 = new S3();
+
+    private final Cache cache = new Cache();
+
+
+    public S3 getS3() {
+        return s3;
+    }
+
+    public Cache getCache() {
+        return cache;
+    }
+
+    public static class S3 {
+
+        private String bucketName;
+
+        public String getBucketName() {
+            return bucketName;
+        }
+
+        public void setBucketName(String bucketName) {
+            this.bucketName = bucketName;
+        }
+    }
+
+    public static class Cache {
+
+        private boolean enabled = false;
+
+        private Duration timeToLive = Duration.ofMinutes(1);
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public Duration getTimeToLive() {
+            return timeToLive;
+        }
+
+        public void setTimeToLive(Duration timeToLive) {
+            this.timeToLive = timeToLive;
+        }
+    }
+}

--- a/spring-boot/autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot/autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 org.togglz.spring.boot.actuate.autoconfigure.TogglzAutoConfiguration
 org.togglz.spring.boot.actuate.autoconfigure.TogglzEndpointAutoConfiguration
+org.togglz.spring.boot.repository.TogglzStateRepositoryAutoConfiguration

--- a/spring-boot/autoconfigure/src/test/java/org/togglz/spring/boot/actuate/BaseTest.java
+++ b/spring-boot/autoconfigure/src/test/java/org/togglz/spring/boot/actuate/BaseTest.java
@@ -34,6 +34,7 @@ import org.togglz.core.user.FeatureUser;
 import org.togglz.spring.boot.actuate.autoconfigure.TogglzAutoConfiguration;
 import org.togglz.spring.boot.actuate.autoconfigure.TogglzEndpointAutoConfiguration;
 import org.togglz.spring.boot.actuate.autoconfigure.TogglzManagementContextConfiguration;
+import org.togglz.spring.boot.repository.TogglzStateRepositoryAutoConfiguration;
 
 public class BaseTest {
 
@@ -44,7 +45,8 @@ public class BaseTest {
                     WebEndpointAutoConfiguration.class,
                     TogglzAutoConfiguration.class,
                     TogglzEndpointAutoConfiguration.class,
-                    TogglzManagementContextConfiguration.class
+                    TogglzManagementContextConfiguration.class,
+                    TogglzStateRepositoryAutoConfiguration.class
                     ));
 
     protected enum MyFeatures implements Feature {

--- a/spring-boot/autoconfigure/src/test/java/org/togglz/spring/boot/repository/TogglzStateRepositoryAutoConfigurationTest.java
+++ b/spring-boot/autoconfigure/src/test/java/org/togglz/spring/boot/repository/TogglzStateRepositoryAutoConfigurationTest.java
@@ -1,0 +1,47 @@
+package org.togglz.spring.boot.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.togglz.core.repository.cache.CachingStateRepository;
+import org.togglz.core.repository.mem.InMemoryStateRepository;
+import org.togglz.s3.S3StateRepository;
+import org.togglz.spring.boot.actuate.BaseTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TogglzStateRepositoryAutoConfigurationTest extends BaseTest {
+
+    @Test
+    void shouldCreateS3StateRepository() {
+        contextRunnerWithFeatureProviderConfig()
+                .withPropertyValues("togglz.state-repository.s3.bucket-name: test")
+                .run((context -> assertThat(context.getBean(S3StateRepository.class)).isNotNull()));
+    }
+
+    @Test
+    void shouldNotCreateS3StateRepositoryWithoutConfiguredBucketName() {
+        contextRunnerWithFeatureProviderConfig()
+                .run((context -> assertThatThrownBy(() -> context.getBean(S3StateRepository.class)).isExactlyInstanceOf(NoSuchBeanDefinitionException.class)));
+    }
+
+    @Test
+    void shouldNotCreateS3StateRepositoryIfAnotherStateRepositoryIsPresent() {
+        contextRunnerWithFeatureProviderConfig()
+                .withPropertyValues("togglz.state-repository.s3.bucket-name: test")
+                .withBean("someOtherRepository", InMemoryStateRepository.class)
+                .run(context -> {
+                    assertThatThrownBy(() -> context.getBean(S3StateRepository.class)).isExactlyInstanceOf(NoSuchBeanDefinitionException.class);
+                    assertThat(context.getBean(InMemoryStateRepository.class)).isNotNull();
+                });
+    }
+
+    @Test
+    void shouldWrapS3StateRepositoryWithCache() {
+        contextRunnerWithFeatureProviderConfig()
+                .withPropertyValues("togglz.state-repository.s3.bucket-name: test")
+                .withPropertyValues("togglz.state-repository.cache.enabled: true")
+                .withPropertyValues("togglz.state-repository.cache.time-to-live: 1m")
+                .run((context -> assertThat(context.getBean(CachingStateRepository.class)).isNotNull()));
+    }
+}

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -28,6 +28,7 @@
     <module>starter-actuator</module>
     <module>starter-console</module>
     <module>starter-core</module>
+    <module>starter-repository</module>
     <module>starter-security</module>
     <module>starter-thymeleaf</module>
     <module>starter-webmvc</module>

--- a/spring-boot/starter-repository/pom.xml
+++ b/spring-boot/starter-repository/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.togglz</groupId>
+    <artifactId>togglz-spring-boot</artifactId>
+    <version>4.4.0</version>
+  </parent>
+
+  <artifactId>togglz-repository-spring-boot-starter</artifactId>
+  <name>Togglz Repository - Spring Boot Starter</name>
+  <description>Togglz Repository - Spring Boot Starter</description>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <!-- Import dependency management from Spring Boot -->
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.togglz</groupId>
+      <artifactId>togglz-core-spring-boot-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.togglz</groupId>
+      <artifactId>togglz-amazon-s3</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
This PR creates adds a spring boot starter to autoconfigure a togglz `StateRepository`.
Currently only S3 is supported but the code should make it easy to extend this starter to all other repository implementations.