### PR TITLE
Align togglz with virtual threads

### DIFF
--- a/core/src/main/java/org/togglz/core/repository/property/PropertyBasedStateRepository.java
+++ b/core/src/main/java/org/togglz/core/repository/property/PropertyBasedStateRepository.java
@@ -3,6 +3,7 @@ package org.togglz.core.repository.property;
 import java.util.List;
 import java.util.Properties;
 
+import java.util.concurrent.locks.ReentrantLock;
 import org.togglz.core.Feature;
 import org.togglz.core.activation.UsernameActivationStrategy;
 import org.togglz.core.repository.FeatureState;
@@ -34,94 +35,102 @@ public class PropertyBasedStateRepository implements StateRepository {
 
     private final PropertySource propertySource;
 
+    private final ReentrantLock lock = new ReentrantLock();
+
     public PropertyBasedStateRepository(PropertySource propertySource) {
 
         this.propertySource = propertySource;
     }
 
-    public synchronized FeatureState getFeatureState(Feature feature) {
+    public FeatureState getFeatureState(Feature feature) {
+        lock.lock();
+        try {
+            // update file if changed
+            propertySource.reloadIfUpdated();
 
-        // update file if changed
-        propertySource.reloadIfUpdated();
+            // if we got this one, the feature is present in the repository
+            String enabledAsStr = propertySource.getValue(getEnabledPropertyName(feature), null);
 
-        // if we got this one, the feature is present in the repository
-        String enabledAsStr = propertySource.getValue(getEnabledPropertyName(feature), null);
+            if (enabledAsStr != null) {
 
-        if (enabledAsStr != null) {
+                // new state instance
+                FeatureState state = new FeatureState(feature);
+                state.setEnabled(isTrue(enabledAsStr));
 
-            // new state instance
-            FeatureState state = new FeatureState(feature);
-            state.setEnabled(isTrue(enabledAsStr));
+                // active strategy (may be null)
+                String strategy = propertySource.getValue(getStrategyPropertyName(feature), null);
+                state.setStrategyId(strategy);
 
-            // active strategy (may be null)
-            String strategy = propertySource.getValue(getStrategyPropertyName(feature), null);
-            state.setStrategyId(strategy);
-
-            // all parameters
-            String paramPrefix = getParameterPropertyName(feature, "");
-            for (String key : propertySource.getKeysStartingWith(paramPrefix)) {
-                String id = key.substring(paramPrefix.length());
-                String value = propertySource.getValue(key, null);
-                state.setParameter(id, value);
-            }
-
-            /*
-             * Backwards compatibility: if there are users stored in the old format, add them to the corresponding property
-             */
-            List<String> additionalUsers = toList(propertySource.getValue(getUsersPropertyName(feature), null));
-            if (!additionalUsers.isEmpty()) {
-
-                // join the users to one list and update the property
-                List<String> currentUsers = toList(state.getParameter(UsernameActivationStrategy.PARAM_USERS));
-                currentUsers.addAll(additionalUsers);
-                state.setParameter(UsernameActivationStrategy.PARAM_USERS, Strings.join(currentUsers, ","));
-
-                // we should set strategy id if it is not yet set
-                if (state.getStrategyId() == null) {
-                    state.setStrategyId(UsernameActivationStrategy.ID);
+                // all parameters
+                String paramPrefix = getParameterPropertyName(feature, "");
+                for (String key : propertySource.getKeysStartingWith(paramPrefix)) {
+                    String id = key.substring(paramPrefix.length());
+                    String value = propertySource.getValue(key, null);
+                    state.setParameter(id, value);
                 }
 
+                /*
+                 * Backwards compatibility: if there are users stored in the old format, add them to the corresponding property
+                 */
+                List<String> additionalUsers = toList(propertySource.getValue(getUsersPropertyName(feature), null));
+                if (!additionalUsers.isEmpty()) {
+
+                    // join the users to one list and update the property
+                    List<String> currentUsers = toList(state.getParameter(UsernameActivationStrategy.PARAM_USERS));
+                    currentUsers.addAll(additionalUsers);
+                    state.setParameter(UsernameActivationStrategy.PARAM_USERS, Strings.join(currentUsers, ","));
+
+                    // we should set strategy id if it is not yet set
+                    if (state.getStrategyId() == null) {
+                        state.setStrategyId(UsernameActivationStrategy.ID);
+                    }
+
+                }
+
+                return state;
+
             }
 
-            return state;
-
+            // the feature is not configured in the repository
+            return null;
+        } finally {
+            lock.unlock();
         }
-
-        // the feature is not configured in the repository
-        return null;
-
     }
 
-    public synchronized void setFeatureState(FeatureState featureState) {
+    public void setFeatureState(FeatureState featureState) {
+        lock.lock();
+        try {
+            // update file if changed
+            propertySource.reloadIfUpdated();
 
-        // update file if changed
-        propertySource.reloadIfUpdated();
+            Feature feature = featureState.getFeature();
+            PropertySource.Editor editor = propertySource.getEditor();
 
-        Feature feature = featureState.getFeature();
-        PropertySource.Editor editor = propertySource.getEditor();
+            // enabled
+            String enabledKey = getEnabledPropertyName(feature);
+            String enabledValue = featureState.isEnabled() ? "true" : "false";
+            editor.setValue(enabledKey, enabledValue);
 
-        // enabled
-        String enabledKey = getEnabledPropertyName(feature);
-        String enabledValue = featureState.isEnabled() ? "true" : "false";
-        editor.setValue(enabledKey, enabledValue);
+            // write strategy id, will be removed if it is null
+            editor.setValue(getStrategyPropertyName(feature), featureState.getStrategyId());
 
-        // write strategy id, will be removed if it is null
-        editor.setValue(getStrategyPropertyName(feature), featureState.getStrategyId());
+            // parameters
+            String paramPrefix = getParameterPropertyName(feature, "");
+            editor.removeKeysStartingWith(paramPrefix);
+            for (String id : featureState.getParameterNames()) {
+                String key = getParameterPropertyName(feature, id);
+                editor.setValue(key, featureState.getParameter(id));
+            }
 
-        // parameters
-        String paramPrefix = getParameterPropertyName(feature, "");
-        editor.removeKeysStartingWith(paramPrefix);
-        for (String id : featureState.getParameterNames()) {
-            String key = getParameterPropertyName(feature, id);
-            editor.setValue(key, featureState.getParameter(id));
+            // remove the old users property if it still exists from the old format
+            editor.setValue(getUsersPropertyName(feature), null);
+
+            // write
+            editor.commit();
+        } finally {
+            lock.unlock();
         }
-
-        // remove the old users property if it still exists from the old format
-        editor.setValue(getUsersPropertyName(feature), null);
-
-        // write
-        editor.commit();
-
     }
 
     private static String getEnabledPropertyName(Feature feature) {

--- a/core/src/test/java/org/togglz/core/repository/cache/CachingStateRepositoryTest.java
+++ b/core/src/test/java/org/togglz/core/repository/cache/CachingStateRepositoryTest.java
@@ -1,46 +1,59 @@
 package org.togglz.core.repository.cache;
 
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.togglz.core.Feature;
 import org.togglz.core.repository.FeatureState;
 import org.togglz.core.repository.StateRepository;
+import org.togglz.core.repository.mem.InMemoryStateRepository;
 import org.togglz.core.util.NamedFeature;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
 
 class CachingStateRepositoryTest {
 
-    private final StateRepository delegate = Mockito.mock(StateRepository.class);
+    private final StateRepository delegate = Mockito.spy(new InMemoryStateRepository());
 
     @BeforeEach
     void setUp() {
         // the mock supports the ENUM
-        Mockito.when(delegate.getFeatureState(DummyFeature.TEST))
-            .thenReturn(new FeatureState(DummyFeature.TEST, true));
+        delegate.setFeatureState(new FeatureState(DummyFeature.TEST, true));
         // and NamedFeature
-        Mockito.when(delegate.getFeatureState(new NamedFeature("TEST")))
-            .thenReturn(new FeatureState(DummyFeature.TEST, true));
+        delegate.setFeatureState(new FeatureState(new NamedFeature("TEST"), true));
+        Mockito.clearInvocations(delegate);
     }
 
     @Test
-    void cachingOfReadOperationsWithTimeToLive() throws InterruptedException {
+    void cachingOfReadOperationsWithTimeToLive() {
         // given
         StateRepository repository = new CachingStateRepository(delegate, 10000);
 
         // when
         for (int i = 0; i < 10; i++) {
             assertTrue(repository.getFeatureState(DummyFeature.TEST).isEnabled());
-            Thread.sleep(10);
+            tickClock(Duration.ofMillis(10));
         }
         // then
-        Mockito.verify(delegate, Mockito.times(1)).getFeatureState(DummyFeature.TEST);
+        Mockito.verify(delegate, times(1)).getFeatureState(DummyFeature.TEST);
     }
 
     @Test
-    void testCacheWithDifferentFeatureImplementations() throws InterruptedException {
+    void testCacheWithDifferentFeatureImplementations() {
 
         StateRepository repository = new CachingStateRepository(delegate, 0);
 
@@ -49,7 +62,7 @@ class CachingStateRepositoryTest {
             Feature feature = (i % 2 == 0) ? DummyFeature.TEST :
                 new NamedFeature(DummyFeature.TEST.name());
             assertTrue(repository.getFeatureState(feature).isEnabled());
-            Thread.sleep(10);
+            tickClock(Duration.ofMillis(10));
         }
 
         // delegate only called once
@@ -58,14 +71,14 @@ class CachingStateRepositoryTest {
     }
 
     @Test
-    void usesTheCacheForTtlOfZero() throws InterruptedException {
+    void usesTheCacheForTtlOfZero() {
 
         StateRepository repository = new CachingStateRepository(delegate, 0);
 
         // do some lookups
         for (int i = 0; i < 10; i++) {
             assertTrue(repository.getFeatureState(DummyFeature.TEST).isEnabled());
-            Thread.sleep(10);
+            tickClock(Duration.ofMillis(10));
         }
 
         // delegate only called once
@@ -74,7 +87,7 @@ class CachingStateRepositoryTest {
     }
 
     @Test
-    void delegateIsUsedWhenCacheExpires() throws InterruptedException {
+    void delegateIsUsedWhenCacheExpires() {
         // given
         long ttl = 5;
         StateRepository repository = new CachingStateRepository(delegate, ttl);
@@ -82,23 +95,23 @@ class CachingStateRepositoryTest {
         // when
         for (int i = 0; i < 5; i++) {
             assertTrue(repository.getFeatureState(DummyFeature.TEST).isEnabled());
-            Thread.sleep(ttl + 30); // wait some small amount of time to let the cache expire
+            tickClock(Duration.ofMillis(ttl + 30)); // wait some small amount of time to let the cache expire
         }
 
         // then
-        Mockito.verify(delegate, Mockito.times(5)).getFeatureState(DummyFeature.TEST);
+        Mockito.verify(delegate, times(5)).getFeatureState(DummyFeature.TEST);
         Mockito.verifyNoMoreInteractions(delegate);
     }
 
     @Test
-    void stateModifyExpiresCache() throws InterruptedException {
+    void stateModifyExpiresCache() {
 
         StateRepository repository = new CachingStateRepository(delegate, 10000);
 
         // do some lookups
         for (int i = 0; i < 5; i++) {
             assertTrue(repository.getFeatureState(DummyFeature.TEST).isEnabled());
-            Thread.sleep(10);
+            tickClock(Duration.ofMillis(10));
         }
 
         // now modify the feature state
@@ -107,11 +120,11 @@ class CachingStateRepositoryTest {
         // do some lookups
         for (int i = 0; i < 5; i++) {
             assertTrue(repository.getFeatureState(DummyFeature.TEST).isEnabled());
-            Thread.sleep(10);
+            tickClock(Duration.ofMillis(10));
         }
 
         // Check for the correct number of invocations
-        Mockito.verify(delegate, Mockito.times(2)).getFeatureState(DummyFeature.TEST);
+        Mockito.verify(delegate, times(2)).getFeatureState(DummyFeature.TEST);
         Mockito.verify(delegate).setFeatureState(Mockito.any(FeatureState.class));
         Mockito.verifyNoMoreInteractions(delegate);
     }
@@ -121,7 +134,182 @@ class CachingStateRepositoryTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> new CachingStateRepository(delegate, -1));
     }
 
+    @Nested
+    class AsyncCacheStateRepositoryTest {
+
+        public static class SlowStateRepository implements StateRepository {
+
+            private final InMemoryStateRepository delegate = new InMemoryStateRepository();
+            private Duration delay = Duration.ofSeconds(2);
+            private CountDownLatch latch;
+
+            @Override
+            public FeatureState getFeatureState(Feature feature) {
+                Instant start = CachingStateRepository.clock.instant();
+                Instant finish = start.plus(delay);
+                if (latch != null) {
+                    latch.countDown();
+                }
+                System.out.println("["+Thread.currentThread().getName()+"] getting... start: " + start + " finish: " + finish + " clock: " + CachingStateRepository.clock.instant());
+                while (CachingStateRepository.clock.instant().isBefore(finish)) {
+                    // busy wait
+                    Thread.onSpinWait();
+                }
+                System.out.println("["+Thread.currentThread().getName()+"] got start: " + start + " finish: " + finish + " clock: " + CachingStateRepository.clock.instant());
+                FeatureState featureState = delegate.getFeatureState(feature);
+                System.out.println("["+Thread.currentThread().getName()+"] returning feature: " + featureState.getFeature().name() + " enabled: " + featureState.isEnabled());
+                return featureState;
+            }
+
+            @Override
+            public void setFeatureState(FeatureState featureState) {
+                delegate.setFeatureState(featureState);
+            }
+
+        }
+        private final SlowStateRepository slowRepository = Mockito.spy(new SlowStateRepository());
+
+        @BeforeEach
+        void setUp() {
+            slowRepository.setFeatureState(new FeatureState(DummyFeature.TEST, true));
+            Mockito.clearInvocations(slowRepository);
+        }
+
+        @AfterEach
+        void tearDown() {
+            tickClock(slowRepository.delay);
+        }
+
+        @Test
+        void returnsNullOnFirstCall() throws InterruptedException {
+            // given
+            slowRepository.latch = new CountDownLatch(1);
+            StateRepository repository = new CachingStateRepository(slowRepository, 10000, Executors.newSingleThreadExecutor());
+
+            // when
+            FeatureState featureState = repository.getFeatureState(DummyFeature.TEST);
+            slowRepository.latch.await();
+
+            // then
+            assertNull(featureState);
+            Mockito.verify(slowRepository).getFeatureState(DummyFeature.TEST);
+            Mockito.verifyNoMoreInteractions(slowRepository);
+        }
+
+        @Test
+        void returnsValueWhenItIsFetchedAndSlowRepositoryIsCalledOnlyOnce() throws InterruptedException {
+            // given
+            StateRepository repository = new CachingStateRepository(slowRepository, 10000, Executors.newSingleThreadExecutor());
+            Duration halfDelay = slowRepository.delay.dividedBy(2);
+            slowRepository.latch = new CountDownLatch(1);
+
+            // when
+            assertNull(repository.getFeatureState(DummyFeature.TEST));
+            slowRepository.latch.await();
+            tickClock(halfDelay);
+            assertNull(repository.getFeatureState(DummyFeature.TEST));
+            tickClock(halfDelay);
+
+            // then
+            Awaitility
+                    .await()
+                    .atMost(100, MILLISECONDS)
+                    .pollDelay(5, MILLISECONDS)
+                    .untilAsserted(() -> assertTrue(repository.getFeatureState(DummyFeature.TEST).isEnabled()));
+            Mockito.verify(slowRepository, Mockito.only()).getFeatureState(DummyFeature.TEST);
+        }
+
+        @Test
+        void updatesCacheOnEntryExpirationAsynchronously() throws InterruptedException {
+            // given
+            Duration ttl = Duration.ofSeconds(10);
+            StateRepository repository = new CachingStateRepository(slowRepository,
+                                                                    ttl.toMillis(),
+                                                                    Executors.newSingleThreadExecutor());
+            slowRepository.latch = new CountDownLatch(1);
+
+            // when
+            assertNull(repository.getFeatureState(DummyFeature.TEST));
+            slowRepository.latch.await();
+            tickClock(slowRepository.delay);
+            Awaitility
+                    .await()
+                    .atMost(100, MILLISECONDS)
+                    .pollDelay(5, MILLISECONDS)
+                    .untilAsserted(() -> {
+                        assertNotNull(repository.getFeatureState(DummyFeature.TEST));
+                        assertTrue(repository.getFeatureState(DummyFeature.TEST).isEnabled());
+                    });
+
+            System.out.println("["+Thread.currentThread().getName()+"] first call");
+
+            // state in repository is changed
+            slowRepository.setFeatureState(new FeatureState(DummyFeature.TEST, false));
+
+            // cache entity expires
+            tickClock(ttl.plus(Duration.ofSeconds(2)));
+
+            // repository returns old value until cache is updated
+            slowRepository.latch = new CountDownLatch(1);
+            assertTrue(repository.getFeatureState(DummyFeature.TEST).isEnabled());
+            slowRepository.latch.await();
+            tickClock(slowRepository.delay);
+            Awaitility
+                    .await()
+                    .atMost(100, MILLISECONDS)
+                    .pollDelay(5, MILLISECONDS)
+                    .untilAsserted(() -> {
+                        assertFalse(repository.getFeatureState(DummyFeature.TEST).isEnabled());
+                    });
+
+            // then slow repository is called only twice (initial and after cache expiration)
+            Mockito.verify(slowRepository, times(2)).getFeatureState(DummyFeature.TEST);
+            Mockito.verify(slowRepository).setFeatureState(Mockito.any());
+            Mockito.verifyNoMoreInteractions(slowRepository);
+        }
+
+        @Test
+        void fetchingTwoFeatureFlagsDoNotBlockEachOther() throws InterruptedException {
+            // given
+            Duration ttl = Duration.ofSeconds(10);
+            slowRepository.latch = new CountDownLatch(2);
+            slowRepository.setFeatureState(new FeatureState(DummyFeature.TEST2, false));
+            Mockito.clearInvocations(slowRepository);
+
+            StateRepository repository = new CachingStateRepository(slowRepository,
+                                                                    ttl.toMillis(),
+                                                                    Executors.newFixedThreadPool(2));
+            assertNull(repository.getFeatureState(DummyFeature.TEST));
+            assertNull(repository.getFeatureState(DummyFeature.TEST2));
+
+            // both requests are in progress slowly downloaded from the slow repository
+            slowRepository.latch.await();
+
+
+            // when the time passes
+            tickClock(slowRepository.delay);
+
+            // then both features appears under the twice of slow repository delay
+            Awaitility
+                    .await()
+                    .atMost(100, MILLISECONDS)
+                    .pollDelay(5, MILLISECONDS)
+                    .untilAsserted(() -> {
+                        assertNotNull(repository.getFeatureState(DummyFeature.TEST));
+                        assertNotNull(repository.getFeatureState(DummyFeature.TEST2));
+                        assertTrue(repository.getFeatureState(DummyFeature.TEST).isEnabled());
+                        assertFalse(repository.getFeatureState(DummyFeature.TEST2).isEnabled());
+                    });
+        }
+
+    }
+
     private enum DummyFeature implements Feature {
-        TEST
+        TEST,
+        TEST2
+    }
+
+    private static void tickClock(Duration tickDuration) {
+        CachingStateRepository.clock = Clock.offset(CachingStateRepository.clock, tickDuration);
     }
 }


### PR DESCRIPTION
Calling togglz from virtual threads causing pinning to the platform (aka carrier thread):
```
Thread[#457,ForkJoinPool-1-worker-13,5,CarrierThreads]
    java.base/java.lang.VirtualThread$VThreadContinuation.onPinned(VirtualThread.java:183)
    java.base/jdk.internal.vm.Continuation.onPinned0(Continuation.java:393)
    java.base/java.lang.VirtualThread.parkNanos(VirtualThread.java:621)
    java.base/java.lang.System$2.parkVirtualThread(System.java:2652)
    java.base/jdk.internal.misc.VirtualThreads.park(VirtualThreads.java:67)
    java.base/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:267)
    java.base/java.util.concurrent.CompletableFuture$Signaller.block(CompletableFuture.java:1866)
    java.base/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3780)
    java.base/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3725)
    java.base/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1939)
    java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2095)
    io.lettuce.core.protocol.AsyncCommand.await(AsyncCommand.java:83)
    io.lettuce.core.internal.Futures.awaitOrCancel(Futures.java:244)
    io.lettuce.core.FutureSyncInvocationHandler.handleInvocation(FutureSyncInvocationHandler.java:75)
    io.lettuce.core.internal.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:80)
    jdk.proxy2/jdk.proxy2.$Proxy182.hgetall(Unknown Source)
    java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    java.base/java.lang.reflect.Method.invoke(Method.java:580)
    io.lettuce.core.support.ConnectionWrapping$DelegateCloseToConnectionInvocationHandler.handleInvocation(ConnectionWrapping.java:215)
    io.lettuce.core.internal.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:80)
    jdk.proxy2/jdk.proxy2.$Proxy182.hgetall(Unknown Source)
    org.togglz.redis.RedisLettuceStateRepository.getFeatureState(RedisLettuceStateRepository.java:52)
    org.togglz.core.repository.cache.CachingStateRepository.reloadFeatureState(CachingStateRepository.java:81) <== monitors:1
    org.togglz.core.repository.cache.CachingStateRepository.getFeatureState(CachingStateRepository.java:73)
    org.togglz.core.manager.DefaultFeatureManager.isActive(DefaultFeatureManager.java:67)
```
To avoid it I replaced synchronized blocks with ReentrantLock.
https://openjdk.org/jeps/444