### PR TITLE
Additional condition for FeatureInterceptor

### DIFF
--- a/spring-boot/autoconfigure/src/main/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzAutoConfiguration.java
+++ b/spring-boot/autoconfigure/src/main/java/org/togglz/spring/boot/actuate/autoconfigure/TogglzAutoConfiguration.java
@@ -243,7 +243,7 @@ public class TogglzAutoConfiguration {
 
     @Configuration
     @ConditionalOnWebApplication
-    @ConditionalOnClass(HandlerInterceptor.class)
+    @ConditionalOnClass({HandlerInterceptor.class, FeatureInterceptor.class})
     @ConditionalOnProperty(prefix = "togglz.web", name = "register-feature-interceptor", havingValue = "true", matchIfMissing = true)
     protected static class TogglzFeatureInterceptorConfiguration implements WebMvcConfigurer {
         @Override


### PR DESCRIPTION
Within my project, current conditions are not enough and cause _ClassNotFoundException_. I do have other conditions met, but don't want to use interceptor and don't have web dependency for it. I know i can define property, but this mechanism comes from another own dependency - I don't wan't to be obligated to define it. 

This little addition shouldn't do harm and will prevent potential errors like mine.