### PR TITLE
togglz#1227: FeatureManagerBuilder insists on manually setting Defaul…

### DIFF
--- a/core/src/main/java/org/togglz/core/manager/FeatureManagerBuilder.java
+++ b/core/src/main/java/org/togglz/core/manager/FeatureManagerBuilder.java
@@ -99,7 +99,7 @@ public class FeatureManagerBuilder {
      * works if you are using the {@link DefaultActivationStrategyProvider}.
      */
     public FeatureManagerBuilder activationStrategy(ActivationStrategy strategy) {
-        if (strategy == null) {
+        if (strategyProvider == null) {
             activationStrategyProvider(new DefaultActivationStrategyProvider());
         }
         if (strategyProvider instanceof DefaultActivationStrategyProvider) {

--- a/core/src/test/java/org/togglz/core/manager/FeatureManagerBuilderTest.java
+++ b/core/src/test/java/org/togglz/core/manager/FeatureManagerBuilderTest.java
@@ -47,6 +47,19 @@ class FeatureManagerBuilderTest {
         });
     }
 
+    @Test
+    void shouldAddStrategyIfNoProviderSpecified() {
+
+        CustomActivationStrategy strategy = new CustomActivationStrategy();
+
+        FeatureManager featureManager = FeatureManagerBuilder.begin()
+                .featureEnum(Features.class)
+                .activationStrategy(strategy)
+                .build();
+
+        assertThat(featureManager.getActivationStrategies()).contains(strategy);
+    }
+
     private enum Features implements Feature {
         SOME_FEATURE
     }


### PR DESCRIPTION
FeatureManagerBuilder insists on manually setting DefaultActivationStrategyProvider when adding an ActivationStrategy