### PR TITLE
Potential fix for code scanning alert no. 6159: Disabled Spring CSRF protection

### DIFF
--- a/samples/spring-boot-security/src/main/java/sample/Application.java
+++ b/samples/spring-boot-security/src/main/java/sample/Application.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;


### PR DESCRIPTION
Potential fix for [https://github.com/togglz/togglz/security/code-scanning/6159](https://github.com/togglz/togglz/security/code-scanning/6159)

To fix the problem, remove the explicit disabling of CSRF so that Spring Security’s default CSRF protection is active. Spring Boot/Spring Security enable CSRF by default, so the minimal, least-invasive fix is to delete the `.csrf(AbstractHttpConfigurer::disable)` call from the `HttpSecurity` configuration. This preserves all existing functionality (authentication, form login, logout) while re-enabling CSRF protection, and does not require any additional configuration if the application already uses Spring Security’s default login form.

Concretely, in `samples/spring-boot-security/src/main/java/sample/Application.java`, inside the `filterChain` method of `ApplicationSecurity`, edit the HTTP security DSL chain so that it no longer calls `.csrf(AbstractHttpConfigurer::disable)`. Leave the rest of the chain (`authorizeHttpRequests`, `.formLogin(Customizer.withDefaults())`, `.logout(Customizer.withDefaults())`) unchanged. No new imports or methods are required, and you do not need to add any explicit CSRF configuration; simply omitting the disable call is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
