### PR TITLE
make org.graalvm.polyglot:js optional again

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,6 +43,7 @@
             <artifactId>js</artifactId>
             <version>${graalvm.version}</version>
             <type>pom</type>
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Graalvm Polyglot seems to have been added as mandatory which makes upgrating harder. This commit makes it optional again.
Addresses https://github.com/togglz/togglz/issues/1325