### PR TITLE
bump owasp-java-html-sanitizer to 20260101.1 to fix vulnerability…

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
       <artifactId>owasp-java-html-sanitizer</artifactId>
-      <version>20240325.1</version>
+      <version>20260101.1</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This fixes CVE-2025-66021 mentioned in https://github.com/togglz/togglz/issues/1326 and https://github.com/togglz/togglz/issues/1247