### PR TITLE
Potential fix for code scanning alert no. 6158: Uncontrolled data used in path expression

### DIFF
--- a/console/src/main/java/org/togglz/console/RequestHandlerBase.java
+++ b/console/src/main/java/org/togglz/console/RequestHandlerBase.java
@@ -44,10 +44,38 @@ public abstract class RequestHandlerBase implements RequestHandler {
         return new String(bos.toByteArray(), UTF_8);
     }
 
+    /**
+     * Load a classpath resource relative to the {@link RequestHandler} package.
+     * <p>
+     * The {@code name} parameter is validated to ensure it does not contain any
+     * path separators or parent directory references, so that callers cannot
+     * accidentally perform path traversal when this method is used with
+     * untrusted input.
+     */
     protected InputStream loadResource(String name) {
+        if (!isSafeResourceName(name)) {
+            return null;
+        }
         String templateName = RequestHandler.class.getPackage().getName().replace('.', '/') + "/" + name;
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         return classLoader.getResourceAsStream(templateName);
+    }
+
+    /**
+     * Returns {@code true} if the given resource name is a single, simple name
+     * without any path separators or parent directory segments.
+     */
+    private boolean isSafeResourceName(String name) {
+        if (name == null || name.isEmpty()) {
+            return false;
+        }
+        if (name.contains("..")) {
+            return false;
+        }
+        if (name.indexOf('/') >= 0 || name.indexOf('\\') >= 0) {
+            return false;
+        }
+        return true;
     }
 
     protected void copy(InputStream input, OutputStream output) throws IOException {


### PR DESCRIPTION
Potential fix for [https://github.com/togglz/togglz/security/code-scanning/6158](https://github.com/togglz/togglz/security/code-scanning/6158)

In general, to fix uncontrolled path usage you either (1) validate and restrict the user input before using it in a path expression, or (2) derive the actual resource path from a strict allow list instead of directly from user input. Here, most validation is already done by the regex in `ResourceHandler`, but `loadResource` is a generic utility method used elsewhere, so making it defensively validate its `name` argument is the safest and least intrusive option.

The best targeted fix without changing observable functionality is:

1. Add a private helper in `RequestHandlerBase` that validates a resource name:
   - Ensure it does not contain `/` or `\` (no path separators).
   - Ensure it does not contain `..` (no path traversal segments).
   - Optionally ensure it is non‑empty.
   - If invalid, return `null` from `loadResource` or throw; to preserve semantics similar to `getResourceAsStream`, we’ll return `null`.

2. Call this validator at the start of `loadResource(String name)`. If the name is invalid, immediately return `null`. Otherwise, construct `templateName` as before and access the resource.

This change is entirely local to `RequestHandlerBase` (file `console/src/main/java/org/togglz/console/RequestHandlerBase.java`). No new imports are needed, and no changes are required to `ResourceHandler`. Functionality for legitimate callers remains the same, but we explicitly prevent path‑style names from being used via this helper.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
