### PR TITLE
fix: return connections to pool in RedisLettuceStateRepository

### DIFF
--- a/redis/src/main/java/org/togglz/redis/RedisLettuceStateRepository.java
+++ b/redis/src/main/java/org/togglz/redis/RedisLettuceStateRepository.java
@@ -47,7 +47,9 @@ public class RedisLettuceStateRepository implements StateRepository {
 
     @Override
     public FeatureState getFeatureState(final Feature feature) {
-        try (final StatefulConnection<String, String> connection = pool.borrowObject()) {
+        StatefulConnection<String, String> connection = null;
+        try {
+            connection = pool.borrowObject();
             final RedisHashCommands<String, String> commands = getCommands(connection);
             final Map<String, String> redisMap = commands.hgetall(keyPrefix + feature.name());
             if (redisMap.isEmpty()) {
@@ -65,12 +67,18 @@ public class RedisLettuceStateRepository implements StateRepository {
             return featureState;
         } catch (Exception e) {
             throw new RedisLettuceStateRepositoryException("Error while getting feature state", e);
+        } finally {
+            if (connection != null) {
+                pool.returnObject(connection);
+            }
         }
     }
 
     @Override
     public void setFeatureState(final FeatureState featureState) {
-        try (final StatefulConnection<String, String> connection = pool.borrowObject()) {
+        StatefulConnection<String, String> connection = null;
+        try {
+            connection = pool.borrowObject();
             final RedisHashCommands<String, String> commands = getCommands(connection);
             final String featureKey = keyPrefix + featureState.getFeature().name();
             commands.hset(featureKey, ENABLED_FIELD, Boolean.toString(featureState.isEnabled()));
@@ -86,6 +94,10 @@ public class RedisLettuceStateRepository implements StateRepository {
             }
         } catch (Exception e) {
             throw new RedisLettuceStateRepositoryException("Error while setting feature state", e);
+        } finally {
+            if (connection != null) {
+                pool.returnObject(connection);
+            }
         }
     }
 

--- a/redis/src/test/java/org/togglz/redis/RedisLettuceStateRepositoryTest.java
+++ b/redis/src/test/java/org/togglz/redis/RedisLettuceStateRepositoryTest.java
@@ -41,6 +41,22 @@ public class RedisLettuceStateRepositoryTest {
     }
 
     @Test
+    public void testConnectionIsReturnedToPool() {
+        final GenericObjectPool<StatefulConnection<String, String>> pool = createPool();
+        final StateRepository stateRepository = new RedisLettuceStateRepository.Builder()
+            .keyPrefix("feature-toggles:")
+            .lettucePool(pool)
+            .build();
+        final Feature feature = new NamedFeature("A_FEATURE");
+
+        stateRepository.getFeatureState(feature);
+        stateRepository.setFeatureState(new FeatureState(feature, true));
+        stateRepository.getFeatureState(feature);
+
+        assertTrue(pool.getNumActive() == 0, "All connections should be returned to the pool after each operation");
+    }
+
+    @Test
     public void testGetFeatureStateNotExisting() {
         final StateRepository stateRepository = aRedisStateRepository();
         final Feature feature = new NamedFeature("A_FEATURE");
@@ -89,11 +105,14 @@ public class RedisLettuceStateRepositoryTest {
 
         // set contents in Redis directly, without using the RedisStateRepository API
         final GenericObjectPool<StatefulConnection<String, String>> lettucePool = createPool();
-        try (final StatefulRedisConnection<String, String> connection = (StatefulRedisConnection<String, String>) lettucePool.borrowObject()) {
+        final StatefulRedisConnection<String, String> connection = (StatefulRedisConnection<String, String>) lettucePool.borrowObject();
+        try {
             final String key = "feature-toggles:A_FEATURE";
             connection.sync().hset(key, "enabled", "true");
             connection.sync().hset(key, "strategy", "TIT_FOR_TAT");
             connection.sync().hset(key, "parameter:MEANING_OF_LIFE", "42");
+        } finally {
+            lettucePool.returnObject(connection);
         }
 
         final Feature feature = new NamedFeature("A_FEATURE");


### PR DESCRIPTION
## Problem

`RedisLettuceStateRepository.getFeatureState` and `setFeatureState` used try-with-resources on `StatefulConnection`. Since `StatefulConnection` implements `AutoCloseable`, this calls `connection.close()` — which destroys the physical TCP connection instead of returning it to the `GenericObjectPool`. Under load this exhausts the pool and causes feature toggle resolution to fail.

## Fix

Replace try-with-resources with explicit `try/finally` blocks that call `pool.returnObject(connection)`, ensuring connections are properly returned to the pool after each operation.

```java
// Before (wrong — closes the physical connection)
try (final StatefulConnection<String, String> connection = pool.borrowObject()) { ... }

// After (correct — returns to pool)
StatefulConnection<String, String> connection = null;
try {
    connection = pool.borrowObject();
    ...
} finally {
    if (connection != null) {
        pool.returnObject(connection);
    }
}
```

A new test `testConnectionIsReturnedToPool` verifies that `pool.getNumActive() == 0` after each operation.

Fixes #1347