### PR TITLE
fix: return pooled connections in RedisLettuceStateRepository

### DIFF
--- a/redis/src/main/java/org/togglz/redis/RedisLettuceStateRepository.java
+++ b/redis/src/main/java/org/togglz/redis/RedisLettuceStateRepository.java
@@ -47,7 +47,9 @@ public class RedisLettuceStateRepository implements StateRepository {
 
     @Override
     public FeatureState getFeatureState(final Feature feature) {
-        try (final StatefulConnection<String, String> connection = pool.borrowObject()) {
+        StatefulConnection<String, String> connection = null;
+        try {
+            connection = pool.borrowObject();
             final RedisHashCommands<String, String> commands = getCommands(connection);
             final Map<String, String> redisMap = commands.hgetall(keyPrefix + feature.name());
             if (redisMap.isEmpty()) {
@@ -65,12 +67,18 @@ public class RedisLettuceStateRepository implements StateRepository {
             return featureState;
         } catch (Exception e) {
             throw new RedisLettuceStateRepositoryException("Error while getting feature state", e);
+        } finally {
+            if (connection != null) {
+                pool.returnObject(connection);
+            }
         }
     }
 
     @Override
     public void setFeatureState(final FeatureState featureState) {
-        try (final StatefulConnection<String, String> connection = pool.borrowObject()) {
+        StatefulConnection<String, String> connection = null;
+        try {
+            connection = pool.borrowObject();
             final RedisHashCommands<String, String> commands = getCommands(connection);
             final String featureKey = keyPrefix + featureState.getFeature().name();
             commands.hset(featureKey, ENABLED_FIELD, Boolean.toString(featureState.isEnabled()));
@@ -86,6 +94,10 @@ public class RedisLettuceStateRepository implements StateRepository {
             }
         } catch (Exception e) {
             throw new RedisLettuceStateRepositoryException("Error while setting feature state", e);
+        } finally {
+            if (connection != null) {
+                pool.returnObject(connection);
+            }
         }
     }
 

--- a/redis/src/test/java/org/togglz/redis/RedisLettuceStateRepositoryTest.java
+++ b/redis/src/test/java/org/togglz/redis/RedisLettuceStateRepositoryTest.java
@@ -89,11 +89,14 @@ public class RedisLettuceStateRepositoryTest {
 
         // set contents in Redis directly, without using the RedisStateRepository API
         final GenericObjectPool<StatefulConnection<String, String>> lettucePool = createPool();
-        try (final StatefulRedisConnection<String, String> connection = (StatefulRedisConnection<String, String>) lettucePool.borrowObject()) {
+        final StatefulRedisConnection<String, String> connection = (StatefulRedisConnection<String, String>) lettucePool.borrowObject();
+        try {
             final String key = "feature-toggles:A_FEATURE";
             connection.sync().hset(key, "enabled", "true");
             connection.sync().hset(key, "strategy", "TIT_FOR_TAT");
             connection.sync().hset(key, "parameter:MEANING_OF_LIFE", "42");
+        } finally {
+            lettucePool.returnObject(connection);
         }
 
         final Feature feature = new NamedFeature("A_FEATURE");
@@ -104,6 +107,22 @@ public class RedisLettuceStateRepositoryTest {
         final FeatureState storedFeatureState = aRedisStateRepository().getFeatureState(feature);
 
         assertTrue(EqualsBuilder.reflectionEquals(expectedFeatureState, storedFeatureState, true));
+    }
+
+    @Test
+    public void testConnectionIsReturnedToPool() {
+        final GenericObjectPool<StatefulConnection<String, String>> pool = createPool();
+        final StateRepository stateRepository = new RedisLettuceStateRepository.Builder()
+            .keyPrefix("feature-toggles:")
+            .lettucePool(pool)
+            .build();
+        final Feature feature = new NamedFeature("A_FEATURE");
+
+        stateRepository.getFeatureState(feature);
+        stateRepository.setFeatureState(new FeatureState(feature, true));
+        stateRepository.getFeatureState(feature);
+
+        assertTrue(pool.getNumActive() == 0, "All connections should be returned to the pool after each operation");
     }
 
     private RedisLettuceStateRepository aRedisStateRepository() {


### PR DESCRIPTION
Replace try-with-resources on StatefulConnection with explicit try/finally blocks that call pool.returnObject(connection). The AutoCloseable.close() call from try-with-resources destroys the underlying TCP connection instead of returning it to the pool, causing pool exhaustion under sustained load (issue #1347).

Also add testConnectionIsReturnedToPool to verify pool.getNumActive() returns to zero after each get/set operation.

Fixes #1347