### PR TITLE
allow changing the kotlin feature state directly instead of using the feature interface and deprecate the old implementation

### DIFF
--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -2,7 +2,8 @@
 
 In Kotlin it's not possible to use the `Feature`-Interface for enum features as in Java, because its `name`-method clashes with the builtin `name`-method of the enum class.
 
-Therefore this wrapper uses a plain enum without implementing `Feature` and provides a `FeatureProvider` to wrap it into a Feature.
+Therefore this wrapper uses a plain enum without implementing `Feature` and provides a `FeatureProvider` to wrap it into a `Feature`.
+`FeatureManagerSupport.enable(...)` and `disable(...)` now take the enum directly.
 
 # Usage (with spring)
 
@@ -25,10 +26,6 @@ Create an enum for your feature toggles but don't extend the Togglz-Feature inte
     }
 }
 ```
-
-
-Now, whenever you need a `Feature` you would create a Feature instance by using the name of your feature enum value as implementation:
- `Feature { KotlinTestFeatures.BAR.name}`
 
 
 For this to work you need to create a spring configuration that creates a `FeatureManager`and a `FeatureProvider`:
@@ -60,7 +57,7 @@ class MyTogglzConfiguration {
 ```
 
 
-##Enable all toggles
+## Enable all toggles
 
 for unit tests:
 ```
@@ -77,8 +74,9 @@ val featureManager: FeatureManager
 FeatureManagerSupport.allEnabledFeatureConfig(featureManager)
 ```
 
-##Enable one toggle
+## Enable one toggle
 
 ```
-FeatureManagerSupport.enable(Feature { KotlinTestFeatures.BAR.name })
+FeatureManagerSupport.enable(KotlinTestFeatures.BAR)
+FeatureManagerSupport.disable(KotlinTestFeatures.BAR)
 ```

--- a/kotlin/src/main/kotlin/org.togglz.kotlin/FeatureManagerSupport.kt
+++ b/kotlin/src/main/kotlin/org.togglz.kotlin/FeatureManagerSupport.kt
@@ -35,12 +35,22 @@ object FeatureManagerSupport {
         clearCache()
     }
 
+    @Deprecated("Use enable(Enum<*>) instead")
     fun enable(feature: Feature) {
         getFeatureManager().enable(feature)
     }
 
+    @Deprecated("Use disable(Enum<*>) instead")
     fun disable(feature: Feature) {
         getFeatureManager().disable(feature)
+    }
+
+    fun enable(feature: Enum<*>) {
+        getFeatureManager().enable(FeatureEnum(feature))
+    }
+
+    fun disable(feature: Enum<*>) {
+        getFeatureManager().disable(FeatureEnum(feature))
     }
 
     private fun shouldRunInTests(feature: Feature, featureManager: FeatureManager): Boolean {

--- a/kotlin/src/test/kotlin/org/togglz/kotlin/FeatureManagerSupportTestLegacy.kt
+++ b/kotlin/src/test/kotlin/org/togglz/kotlin/FeatureManagerSupportTestLegacy.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import org.togglz.core.context.StaticFeatureManagerProvider
 import org.togglz.kotlin.FeatureManagerSupport.createFeatureManagerForTest
 
-internal class FeatureManagerSupportTest {
+internal class FeatureManagerSupportTestLegacy {
 
     @Test
     internal fun `should change toggle state after enable`() {
@@ -15,22 +15,22 @@ internal class FeatureManagerSupportTest {
         KotlinTestFeatures.BAR.isActive() shouldBe true
         KotlinTestFeatures.FOO.isActive() shouldBe true
 
-        FeatureManagerSupport.disable(KotlinTestFeatures.BAR)
+        FeatureManagerSupport.disable({ KotlinTestFeatures.BAR.name })
 
         KotlinTestFeatures.BAR.isActive() shouldBe false
 
-        FeatureManagerSupport.enable(KotlinTestFeatures.BAR)
+        FeatureManagerSupport.enable({ KotlinTestFeatures.BAR.name })
         KotlinTestFeatures.BAR.isActive() shouldBe true
     }
 
     @Test
     internal fun `should change toggle state after disable`() {
         createFeatureManagerForTest(KotlinTestFeatures::class)
-        FeatureManagerSupport.disable(KotlinTestFeatures.BAR)
+        FeatureManagerSupport.disable({ KotlinTestFeatures.BAR.name })
 
         KotlinTestFeatures.BAR.isActive() shouldBe false
 
-        FeatureManagerSupport.enable(KotlinTestFeatures.BAR)
+        FeatureManagerSupport.enable({ KotlinTestFeatures.BAR.name })
         KotlinTestFeatures.BAR.isActive() shouldBe true
     }
 
@@ -38,7 +38,7 @@ internal class FeatureManagerSupportTest {
     internal fun `should enable all toggles`() {
         //given
         val featureManager = createFeatureManagerForTest(KotlinTestFeatures::class)
-        FeatureManagerSupport.disable(KotlinTestFeatures.FOO)
+        FeatureManagerSupport.disable({ KotlinTestFeatures.FOO.name })
         KotlinTestFeatures.FOO.isActive() shouldBe false
 
         //when
@@ -53,7 +53,7 @@ internal class FeatureManagerSupportTest {
         //given
         val featureManager = createFeatureManagerForTest(KotlinTestFeatures::class)
 
-        FeatureManagerSupport.enable(KotlinTestFeatures.FOO)
+        FeatureManagerSupport.enable({ KotlinTestFeatures.FOO.name })
         KotlinTestFeatures.FOO.isActive() shouldBe true
 
         //when
@@ -68,4 +68,3 @@ internal class FeatureManagerSupportTest {
         StaticFeatureManagerProvider.setFeatureManager(null)
     }
 }
-


### PR DESCRIPTION
With this change you can disable a feature using 
```
FeatureManagerSupport.disable(KotlinTestFeatures.BAR)
```
instead of
```
FeatureManagerSupport.disable{KotlinTestFeatures.BAR.name}
```
Since the latter uses an interface having the same name as the enum you actually want to disable, the new approach is not event shorter but also more exact.